### PR TITLE
frecent_paths: dedupe entries by path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -186,7 +186,7 @@ alias z='pazi_cd'
             }
         } else {
             // unwrap is safe because of the 'matches.len() == 0' check above.
-            print!("{}", matches.first().unwrap().0);
+            print!("{}", matches.last().unwrap().0);
             process::exit(0);
         }
     };


### PR DESCRIPTION
Also order things more consistently; it's always least-frecent ->
more-frecent in the paths ocming out of frecent_paths, and thus main
should take 'last'.

This is primarily because '-i' and 'z' (with no args) order them as
most-important-last since the bottom of the list is more immediately
reachable for a viewer from the input prompt.

Fixes #18