### PR TITLE
 init: move into subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ supported):
 
 ```sh
 if command -v pazi &>/dev/null; then
-  eval "$(pazi --init zsh)" # or 'bash'
+  eval "$(pazi init zsh)" # or 'bash'
 fi
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+// This token 'lib' file is here for reusing code between the bin and integ tests.
+
+pub mod supported_shells;

--- a/src/supported_shells.rs
+++ b/src/supported_shells.rs
@@ -1,0 +1,1 @@
+pub const SUPPORTED_SHELLS: [&str; 2] = ["zsh", "bash"];

--- a/tests/integ.rs
+++ b/tests/integ.rs
@@ -85,7 +85,7 @@ mod integ_tests {
 set -e
 export PS1="{2}" # sep so we know when our commands finished
 export PATH=$PATH:$(dirname "{0}")
-eval "$("{0}" --init {1})"
+eval "$("{0}" init {1})"
 "#,
                     pazi.to_str().unwrap(),
                     shell,

--- a/tests/integ.rs
+++ b/tests/integ.rs
@@ -4,6 +4,8 @@ mod testshell;
 mod integ_tests {
     extern crate pty;
     extern crate tempdir;
+    extern crate pazi;
+    use integ_tests::pazi::supported_shells::SUPPORTED_SHELLS;
     use super::testshell::TestShell;
     use self::tempdir::TempDir;
     use std::process::Command;
@@ -24,8 +26,10 @@ mod integ_tests {
 
     #[test]
     fn it_jumps() {
-        it_jumps_shell("zsh");
-        it_jumps_shell("bash");
+        for shell in SUPPORTED_SHELLS.iter() {
+            println!("testing: {}", shell);
+            it_jumps_shell(shell);
+        }
     }
 
     fn it_jumps_shell(shell: &str) {
@@ -38,9 +42,12 @@ mod integ_tests {
 
     #[test]
     fn it_jumps_to_more_frecent_items() {
-        it_jumps_to_more_frecent_items_shell("zsh");
-        it_jumps_to_more_frecent_items_shell("bash");
+        for shell in SUPPORTED_SHELLS.iter() {
+            println!("testing: {}", shell);
+            it_jumps_to_more_frecent_items_shell(shell);
+        }
     }
+
     fn it_jumps_to_more_frecent_items_shell(shell: &str) {
         let mut h = Harness::new(&pazi_bin().join("pazi"), shell);
 


### PR DESCRIPTION
There's no major reason to do this, it just seems like a slightly nicer
ux