### PR TITLE
 zsh/bash: handle more error return codes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -97,9 +97,11 @@ autoload -Uz add-zsh-hook
 add-zsh-hook chpwd __pazi_add_dir
 
 pazi_cd() {
-    [ "$#" -eq 0 ] && pazi && return 0
+    if [ "$#" -eq 0 ]; then pazi; return $?; fi
     [[ "$@[(r)--help]" == "--help" ]] && pazi --help && return 0
     local to="$(pazi --dir "$@")"
+    local ret=$?
+    if [ "${ret}" != "0" ]; then return "$ret"; fi
     [ -z "${to}" ] && return 1
     cd "${to}"
 }
@@ -130,8 +132,10 @@ else
 fi
 
 pazi_cd() {
-    [ "$#" -eq 0 ] && pazi && return 0
+    if [ "$#" -eq 0 ]; then pazi; return $?; fi
     local to="$(pazi --dir "$@")"
+    local ret=$?
+    if [ "${ret}" != "0" ]; then return "$ret"; fi
     [ -z "${to}" ] && return 1
     cd "${to}"
 }

--- a/tests/src/harness/testshell/mod.rs
+++ b/tests/src/harness/testshell/mod.rs
@@ -59,6 +59,9 @@ impl vte::Perform for VTEData {
                     self.current_line.pop();
                 }
             }
+            '\t' => {
+                self.print('\t');
+            }
             _ => {
                 println!("[VTEData execute]: ignoring {}", byte);
             }

--- a/tests/src/integ.rs
+++ b/tests/src/integ.rs
@@ -94,3 +94,29 @@ fn it_imports_from_fasd_shell(shell: &Shell) {
         assert_eq!(h.jump("tmp"), root.join("tmp").to_string_lossy());
     }
 }
+
+#[test]
+fn it_prints_list_on_lonely_z() {
+    // running just 'z' or just 'pazi' should print a directory listing, not error
+    for shell in SUPPORTED_SHELLS.iter() {
+        let s = Shell::from_str(shell);
+        it_prints_list_on_lonely_z_shell(&s);
+    }
+}
+
+fn it_prints_list_on_lonely_z_shell(shell: &Shell) {
+    let tmpdir = TempDir::new("pazi_integ").unwrap();
+    let root = tmpdir.path();
+    let mut h = Harness::new(&root, &Pazi, shell);
+
+    h.create_dir(&root.join("1/tmp").to_string_lossy());
+    h.create_dir(&root.join("2/tmp").to_string_lossy());
+    h.visit_dir(&root.join("1/tmp").to_string_lossy());
+    h.visit_dir(&root.join("2/tmp").to_string_lossy());
+
+    let z_res = h.run_cmd("z");
+    let pazi_res = h.run_cmd("pazi");
+
+    assert_eq!(z_res, pazi_res);
+    assert!(z_res.contains(&root.join("1/tmp").to_string_lossy().to_string()));
+}


### PR DESCRIPTION
The messup with flag handling I had in #30 resulted in some silly behavior (printing an error and zapping on 'z'). This would have caused that behavior to be a little less silly.

It also adds an integ test which wouldn't have caught it 🤷‍