### PR TITLE
Optimized those benchmarks *good*

### DIFF
--- a/src/frecency.rs
+++ b/src/frecency.rs
@@ -99,7 +99,8 @@ where
     }
 
     pub fn retain<F>(&mut self, mut pred: F) -> bool
-        where F: FnMut(&T) -> bool,
+    where
+        F: FnMut(&T) -> bool,
     {
         let mut any_removed = false;
         self.frecency.retain(|k, _| {

--- a/src/importers/mod.rs
+++ b/src/importers/mod.rs
@@ -1,6 +1,6 @@
 use std::env;
 use frecent_paths::PathFrecency;
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 use std::fs;
 use std::io::BufRead;
 use std::io::BufReader;
@@ -18,15 +18,16 @@ impl Fasd {
             // For proper compatibility, this should use 'shellexpand' or a similar crate.
             Ok(dir) => PathBuf::from(dir),
             Err(_) => {
-                let home = env::home_dir()
-                    .ok_or_else(|| "could not get home directory".to_string())?;
+                let home =
+                    env::home_dir().ok_or_else(|| "could not get home directory".to_string())?;
                 home.join(".fasd")
             }
         };
 
-        let f = fs::File::open(&fasd_data).map_err(|e| format!("could not open {:?} for import: {}", &fasd_data, e))?;
+        let f = fs::File::open(&fasd_data)
+            .map_err(|e| format!("could not open {:?} for import: {}", &fasd_data, e))?;
 
-        let mut stats = ImportStats{
+        let mut stats = ImportStats {
             items_visited: 0,
             items_considered: 0,
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,28 +181,31 @@ alias z='pazi_cd'
 
     if let Some(import_matches) = flags.subcommand_matches("import") {
         match import_matches.value_of("autojumper") {
-            Some("fasd") => {
-                match importers::Fasd::import(&mut frecency) {
-                    Ok(stats) => {
-                        match frecency.save_to_disk() {
-                            Ok(_) => {
-                                println!("imported {} items from fasd (out of {} in its db)", stats.items_visited, stats.items_considered);
-                                process::exit(0);
-                            }
-                            Err(e) => {
-                                println!("pazi: error adding directory: {}", e);
-                                process::exit(1);
-                            }
-                        }
+            Some("fasd") => match importers::Fasd::import(&mut frecency) {
+                Ok(stats) => match frecency.save_to_disk() {
+                    Ok(_) => {
+                        println!(
+                            "imported {} items from fasd (out of {} in its db)",
+                            stats.items_visited, stats.items_considered
+                        );
+                        process::exit(0);
                     }
                     Err(e) => {
-                        println!("pazi: error importing from fasd: {}", e);
+                        println!("pazi: error adding directory: {}", e);
                         process::exit(1);
                     }
+                },
+                Err(e) => {
+                    println!("pazi: error importing from fasd: {}", e);
+                    process::exit(1);
                 }
-            }
+            },
             Some(s) => {
-                println!("{}\n\nUnsupported import target: {}", import_matches.usage(), s);
+                println!(
+                    "{}\n\nUnsupported import target: {}",
+                    import_matches.usage(),
+                    s
+                );
                 std::process::exit(1);
             }
             None => {

--- a/tests/src/bench.rs
+++ b/tests/src/bench.rs
@@ -12,7 +12,7 @@ fn cd_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
     let dir1p = root.join("tmp1");
     let dir2p = root.join("tmp2");
     let dir1 = dir1p.to_str().unwrap();
-    let dir2 = dir1p.to_str().unwrap();
+    let dir2 = dir2p.to_str().unwrap();
 
     h.create_dir(&dir1);
     h.create_dir(&dir2);

--- a/tests/src/bench.rs
+++ b/tests/src/bench.rs
@@ -20,6 +20,7 @@ fn cd_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
     // ensure we hit different directories on adjacent iterations; autojumpers may validly avoid
     // doing work on 'cd .'.
     let mut iter = 0;
+
     b.iter(move || {
         let dir = if iter % 2 == 0 {
             &dir1

--- a/tests/src/bench.rs
+++ b/tests/src/bench.rs
@@ -1,8 +1,8 @@
-extern crate test;
 extern crate tempdir;
+extern crate test;
 
 use tempdir::TempDir;
-use harness::{Harness, Autojumper, Shell, Pazi, Fasd, NoJumper};
+use harness::{Autojumper, Fasd, Harness, NoJumper, Pazi, Shell};
 use self::test::Bencher;
 
 fn cd_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
@@ -22,11 +22,7 @@ fn cd_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
     let mut iter = 0;
 
     b.iter(move || {
-        let dir = if iter % 2 == 0 {
-            &dir1
-        } else {
-            &dir2
-        };
+        let dir = if iter % 2 == 0 { &dir1 } else { &dir2 };
         iter += 1;
         h.visit_dir(dir)
     });
@@ -69,25 +65,23 @@ fn jump_large_db_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
     });
 }
 
-
 fn cd_50_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
     let tmpdir = TempDir::new("pazi_bench").unwrap();
     let root = tmpdir.path();
     let mut h = Harness::new(&root, jumper, shell);
-    let dirs = (0..50).map(|num| {
-        format!("{}/dir{}", root.to_str().unwrap(), num)
-    }).collect::<Vec<_>>();
+    let dirs = (0..50)
+        .map(|num| format!("{}/dir{}", root.to_str().unwrap(), num))
+        .collect::<Vec<_>>();
     for dir in &dirs {
         h.create_dir(&dir);
     }
 
-    let cmd = dirs.iter().map(|el| {
-        format!("cd '{}'", el)
-    }).collect::<Vec<_>>().join(" && ");
+    let cmd = dirs.iter()
+        .map(|el| format!("cd '{}'", el))
+        .collect::<Vec<_>>()
+        .join(" && ");
 
-    b.iter(move || {
-        h.run_cmd(&cmd)
-    });
+    b.iter(move || h.run_cmd(&cmd));
 }
 
 // This file is generated with 'build.rs' based on the contents of 'src/benches.csv'; to change the

--- a/tests/src/harness/autojumpers/fasd.rs
+++ b/tests/src/harness/autojumpers/fasd.rs
@@ -8,30 +8,35 @@ pub struct Fasd;
 impl Autojumper for Fasd {
     fn bin_path(&self) -> String {
         let crate_dir = env::var("CARGO_MANIFEST_DIR").expect("build with cargo");
-        let fasd_path = Path::new(&crate_dir)
-            .join(format!("testbins/fasd/fasd"));
+        let fasd_path = Path::new(&crate_dir).join(format!("testbins/fasd/fasd"));
 
         if !fasd_path.exists() {
             panic!("update submodules before running benches");
         }
-        fasd_path.canonicalize().unwrap().to_string_lossy().to_string()
+        fasd_path
+            .canonicalize()
+            .unwrap()
+            .to_string_lossy()
+            .to_string()
     }
 
     fn init_for(&self, shell: &Shell) -> String {
         match shell {
-            &Shell::Bash => {
-                format!(r#"
+            &Shell::Bash => format!(
+                r#"
 # Ensure history is not blank; fasd grabs commands to process from history
 # (https://github.com/clvv/fasd/blob/90b531a5daaa545c74c7d98974b54cbdb92659fc/fasd#L127-L130)
 # and, if history is empty, will error out
 echo "echo hello world" >> ~/.bash_history
 
 eval "$({} --init posix-alias bash-hook)"
-"#, self.bin_path())
-            }
-            &Shell::Zsh => {
-                format!(r#"eval "$({} --init posix-alias zsh-hook)""#, self.bin_path())
-            }
+"#,
+                self.bin_path()
+            ),
+            &Shell::Zsh => format!(
+                r#"eval "$({} --init posix-alias zsh-hook)""#,
+                self.bin_path()
+            ),
             &Shell::Conch => unimplemented!(),
         }
     }

--- a/tests/src/harness/autojumpers/pazi.rs
+++ b/tests/src/harness/autojumpers/pazi.rs
@@ -20,9 +20,7 @@ impl Autojumper for Pazi {
 
     fn init_for(&self, shell: &Shell) -> String {
         match shell {
-            &Shell::Bash | &Shell::Zsh => {
-                format!(r#"eval "$(pazi init {})""#, shell.name())
-            }
+            &Shell::Bash | &Shell::Zsh => format!(r#"eval "$(pazi init {})""#, shell.name()),
             &Shell::Conch => unimplemented!(),
         }
     }

--- a/tests/src/harness/mod.rs
+++ b/tests/src/harness/mod.rs
@@ -19,10 +19,9 @@ pub struct Harness {
 impl Harness {
     pub fn new(root: &Path, jumper: &Autojumper, shell: &Shell) -> Self {
         let ps1 = "==PAZI==> ";
-        let home = Path::new(&root).join("home/pazi");
         shell.setup(&root, jumper, ps1);
 
-        let mut cmd = shell.command(&root);
+        let cmd = shell.command(&root);
         let testshell = TestShell::new(cmd, ps1);
         Harness {
             testshell: testshell,

--- a/tests/src/harness/mod.rs
+++ b/tests/src/harness/mod.rs
@@ -41,8 +41,7 @@ impl Harness {
     }
 
     pub fn jump(&mut self, search: &str) -> String {
-        self.testshell
-            .run(&format!("z '{}' && pwd", search))
+        self.testshell.run(&format!("z '{}' && pwd", search))
     }
 
     pub fn run_cmd(&mut self, cmd: &str) -> String {

--- a/tests/src/harness/shells.rs
+++ b/tests/src/harness/shells.rs
@@ -7,8 +7,7 @@ use std::process::Command;
 pub enum Shell {
     Bash,
     Zsh,
-    #[allow(dead_code)]
-    Conch,
+    #[allow(dead_code)] Conch,
 }
 
 impl Shell {

--- a/tests/src/harness/shells.rs
+++ b/tests/src/harness/shells.rs
@@ -7,6 +7,7 @@ use std::process::Command;
 pub enum Shell {
     Bash,
     Zsh,
+    #[allow(dead_code)]
     Conch,
 }
 

--- a/tests/src/harness/testshell/mod.rs
+++ b/tests/src/harness/testshell/mod.rs
@@ -19,11 +19,19 @@ pub struct TestShell {
 
 // VTEData is to handle lines after the mess of vte terminal stuff.
 // It keeps track of newlines and such
-#[derive(PartialEq, Clone, Debug)]
+#[derive(Debug)]
 struct VTEData {
     current_line_cursor: usize,
     pub current_line: String,
     pub scrollback: Vec<String>,
+}
+
+// VTEDataLen is used as a sorta cheap hash for comparing whether VTEData has changed in a
+// meaningful way.
+#[derive(PartialEq, Clone, Debug)]
+struct VTEDataLen {
+    pub current_line: usize,
+    pub scrollback: usize,
 }
 
 impl VTEData {
@@ -32,6 +40,13 @@ impl VTEData {
             current_line_cursor: 0,
             current_line: String::new(),
             scrollback: Vec::new(),
+        }
+    }
+
+    fn len(&self) -> VTEDataLen {
+        VTEDataLen{
+            current_line: self.current_line.len(),
+            scrollback: self.scrollback.len(),
         }
     }
 }
@@ -47,7 +62,7 @@ impl vte::Perform for VTEData {
         match byte as char {
             '\n' => {
                 self.scrollback.push(self.current_line.clone());
-                self.current_line = String::new();
+                self.current_line.truncate(0);
             }
             '\r' => {
                 self.current_line_cursor = 0;
@@ -126,9 +141,9 @@ impl TestShell {
             // vte stuff
             let mut data = VTEData::new();
             let mut statemachine = vte::Parser::new();
-            // Keep a copy of the vte so we know when things have changed vs, e.g., a character
-            // just being a control sequence.
-            let mut last_data = data.clone();
+            // Keep a record of the last vte-length info we saw so we can detect meaningful
+            // changes.
+            let mut last_len = data.len();
 
             // Have we seen the starting PS1 yet?
             let mut last_prompt_scrollback_count = -1;
@@ -144,7 +159,7 @@ impl TestShell {
                 }
                 for byte in &buf[..nread] {
                     statemachine.advance(&mut data, *byte);
-                    if last_data == data {
+                    if last_len == data.len() {
                         // control character or whatever, we don't care
                         continue;
                     }
@@ -158,11 +173,11 @@ impl TestShell {
                         write_command_out
                             .send(current_command_output.join("\n"))
                             .unwrap();
-                        current_command_output = Vec::new();
+                        current_command_output.truncate(0);
                         // mark that we've seen this prompt, don't handle it again even if there's
                         // backspacing
                         last_prompt_scrollback_count = data.scrollback.len() as i32;
-                    } else if data.scrollback.len() > last_data.scrollback.len()
+                    } else if data.scrollback.len() > last_len.scrollback
                         && last_prompt_scrollback_count != -1
                     {
                         // this only happens if the last character was a newline since we're
@@ -178,7 +193,7 @@ impl TestShell {
                             current_command_output.push(last_line.to_string());
                         }
                     }
-                    last_data = data.clone();
+                    last_len = data.len();
                 }
             }
         });

--- a/tests/src/harness/testshell/mod.rs
+++ b/tests/src/harness/testshell/mod.rs
@@ -44,7 +44,7 @@ impl VTEData {
     }
 
     fn len(&self) -> VTEDataLen {
-        VTEDataLen{
+        VTEDataLen {
             current_line: self.current_line.len(),
             scrollback: self.scrollback.len(),
         }
@@ -198,8 +198,9 @@ impl TestShell {
             }
         });
 
-
-        command_out.recv_timeout(Duration::from_secs(5)).expect("did not get initial prompt");
+        command_out
+            .recv_timeout(Duration::from_secs(5))
+            .expect("did not get initial prompt");
 
         TestShell {
             fork: fork,

--- a/tests/src/integ.rs
+++ b/tests/src/integ.rs
@@ -3,7 +3,7 @@ extern crate tempdir;
 
 use integ::pazi::supported_shells::SUPPORTED_SHELLS;
 use tempdir::TempDir;
-use harness::{Harness, Shell, Pazi, Fasd};
+use harness::{Fasd, Harness, Pazi, Shell};
 use std::time::Duration;
 use std::thread::sleep;
 
@@ -89,7 +89,10 @@ fn it_imports_from_fasd_shell(shell: &Shell) {
 
     {
         let mut h = Harness::new(&root, &Pazi, shell);
-        assert_eq!(h.run_cmd("pazi import fasd").trim(), "imported 1 items from fasd (out of 1 in its db)");
+        assert_eq!(
+            h.run_cmd("pazi import fasd").trim(),
+            "imported 1 items from fasd (out of 1 in its db)"
+        );
         assert_eq!(h.jump("tmp"), root.join("tmp").to_string_lossy());
     }
 }

--- a/tests/src/integ.rs
+++ b/tests/src/integ.rs
@@ -6,7 +6,6 @@ use tempdir::TempDir;
 use harness::{Harness, Shell, Pazi, Fasd};
 use std::time::Duration;
 use std::thread::sleep;
-use std;
 
 #[test]
 fn it_jumps() {


### PR DESCRIPTION
🔥 🚗 ⏩ ⏩ 💨 

Before:
```
$ cargo bench --features=nightly cd_bench_nojumper
running 2 tests
test bench::cd_bench_nojumper_bash        ... bench:   5,886,133 ns/iter (+/- 3,493,799)
test bench::cd_bench_nojumper_zsh         ... bench:  14,084,141 ns/iter (+/- 9,686,470)
```

After:
```
$ cargo bench --features=nightly cd_bench_nojumper
running 2 tests
test bench::cd_bench_nojumper_bash        ... bench:      86,638 ns/iter (+/- 4,373)
test bench::cd_bench_nojumper_zsh         ... bench:      32,791 ns/iter (+/- 1,888)
```

Sorry about throwing in the noise of `cargo fmt` too, just ignore that commit for reviewing. The first two are the important ones that make real changes.