### PR TITLE
main: split out 'shells' module for init

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
 // This token 'lib' file is here for reusing code between the bin and integ tests.
 
-pub mod supported_shells;
+pub mod shells;

--- a/src/shells/bash.rs
+++ b/src/shells/bash.rs
@@ -1,0 +1,36 @@
+use super::Shell;
+
+pub struct Bash;
+
+impl Shell for Bash {
+    fn pazi_init(&self) -> &'static str {
+        // ty to mklement0 for this suggested append method:
+        // https://stackoverflow.com/questions/3276247/is-there-a-hook-in-bash-to-find-out-when-the-cwd-changes#comment35222599_3276280
+        // Used under cc by-sa 3.0
+        r#"
+__pazi_add_dir() {
+    # TODO: should pazi keep track of this itself in its datadir?
+    if [[ "${__PAZI_LAST_PWD}" != "${PWD}" ]]; then
+        pazi --add-dir "${PWD}"
+    fi
+    __PAZI_LAST_PWD="${PWD}"
+}
+
+if [[ -z "${PROMPT_COMMAND}" ]]; then
+    PROMPT_COMMAND="__pazi_add_dir;"
+else
+    PROMPT_COMMAND="$(read newVal <<<"$PROMPT_COMMAND"; echo "${newVal%;}; __pazi_add_dir;")"
+fi
+
+pazi_cd() {
+    if [ "$#" -eq 0 ]; then pazi; return $?; fi
+    local to="$(pazi --dir "$@")"
+    local ret=$?
+    if [ "${ret}" != "0" ]; then return "$ret"; fi
+    [ -z "${to}" ] && return 1
+    cd "${to}"
+}
+alias z='pazi_cd'
+"#
+    }
+}

--- a/src/shells/mod.rs
+++ b/src/shells/mod.rs
@@ -1,0 +1,18 @@
+mod zsh;
+mod bash;
+use self::zsh::Zsh;
+use self::bash::Bash;
+
+pub const SUPPORTED_SHELLS: [&str; 2] = ["zsh", "bash"];
+
+pub fn from_name(name: &str) -> Option<&Shell> {
+    match name {
+        "bash" => Some(&Bash),
+        "zsh" => Some(&Zsh),
+        _ => None,
+    }
+}
+
+pub trait Shell {
+    fn pazi_init(&self) -> &'static str;
+}

--- a/src/shells/zsh.rs
+++ b/src/shells/zsh.rs
@@ -1,0 +1,27 @@
+use super::Shell;
+
+pub struct Zsh;
+
+impl Shell for Zsh {
+    fn pazi_init(&self) -> &'static str {
+        r#"
+__pazi_add_dir() {
+    pazi --add-dir "${PWD}"
+}
+
+autoload -Uz add-zsh-hook
+add-zsh-hook chpwd __pazi_add_dir
+
+pazi_cd() {
+    if [ "$#" -eq 0 ]; then pazi; return $?; fi
+    [[ "$@[(r)--help]" == "--help" ]] && pazi --help && return 0
+    local to="$(pazi --dir "$@")"
+    local ret=$?
+    if [ "${ret}" != "0" ]; then return "$ret"; fi
+    [ -z "${to}" ] && return 1
+    cd "${to}"
+}
+alias z='pazi_cd'
+"#
+    }
+}

--- a/src/supported_shells.rs
+++ b/src/supported_shells.rs
@@ -1,1 +1,0 @@
-pub const SUPPORTED_SHELLS: [&str; 2] = ["zsh", "bash"];

--- a/tests/src/integ.rs
+++ b/tests/src/integ.rs
@@ -1,7 +1,7 @@
 extern crate pazi;
 extern crate tempdir;
 
-use integ::pazi::supported_shells::SUPPORTED_SHELLS;
+use integ::pazi::shells::SUPPORTED_SHELLS;
 use tempdir::TempDir;
 use harness::{Fasd, Harness, Pazi, Shell};
 use std::time::Duration;


### PR DESCRIPTION
This moves giant const strings off into functions where they look less
egregious.