### PR TITLE
 tests/benches: add 'autojump' benches 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "tests/testbins/fasd"]
 	path = tests/testbins/fasd
 	url = https://github.com/clvv/fasd.git
+[submodule "tests/testbins/autojump"]
+	path = tests/testbins/autojump
+	url = https://github.com/wting/autojump

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
     packages:
     - zsh
     - bash
+    - python3
 
 env:
   global:
@@ -20,4 +21,4 @@ env:
 script:
 - cargo build --verbose --examples
 - cargo build --release # for integ tests
-- cd tests && cargo test -v --features="$([ "${TRAVIS_RUST_VERSION}" == "nightly" ] && echo nightly || echo default)"
+- cd tests && cargo test -v --features="$([ "${TRAVIS_RUST_VERSION}" == "nightly" ] && echo nightly || echo default)" -- --test-threads=1

--- a/tests/src/bench.rs
+++ b/tests/src/bench.rs
@@ -2,7 +2,7 @@ extern crate tempdir;
 extern crate test;
 
 use tempdir::TempDir;
-use harness::{Autojumper, Fasd, Harness, NoJumper, Pazi, Shell};
+use harness::{Autojumper, Fasd, Harness, NoJumper, Pazi, Shell, Autojump};
 use self::test::Bencher;
 
 fn cd_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {

--- a/tests/src/benches.csv
+++ b/tests/src/benches.csv
@@ -6,7 +6,7 @@
 # 3. A space-separated list of shells, 's'
 # 
 # The generated benchmarks will test all combinations j * s for that function.
-cd_bench, NoJumper Pazi Fasd, Zsh Bash
-cd_50_bench, NoJumper Pazi Fasd, Zsh Bash
-jump_bench, Pazi Fasd, Zsh Bash
-jump_large_db_bench, Pazi Fasd, Zsh Bash
+cd_bench, NoJumper Pazi Fasd Autojump, Zsh Bash
+cd_50_bench, NoJumper Pazi Fasd Autojump, Zsh Bash
+jump_bench, Pazi Fasd Autojump, Zsh Bash
+jump_large_db_bench, Pazi Fasd Autojump, Zsh Bash

--- a/tests/src/harness/autojumpers/autojump.rs
+++ b/tests/src/harness/autojumpers/autojump.rs
@@ -1,0 +1,53 @@
+use super::Autojumper;
+use harness::Shell;
+use std::env;
+use std::path::Path;
+
+// https://github.com/wting/autojump
+pub struct Autojump;
+
+impl Autojump {
+    fn shell_path(&self, shell: &str) -> String {
+        let crate_dir = env::var("CARGO_MANIFEST_DIR").expect("build with cargo");
+        let shell_path = Path::new(&crate_dir).join(format!("testbins/autojump/bin/autojump.{}", shell));
+
+        if !shell_path.exists() {
+            panic!("update submodules before running benches");
+        }
+        shell_path
+            .canonicalize()
+            .unwrap()
+            .to_string_lossy()
+            .to_string()
+
+    }
+}
+
+
+impl Autojumper for Autojump {
+    fn bin_path(&self) -> String {
+        let crate_dir = env::var("CARGO_MANIFEST_DIR").expect("build with cargo");
+        let bin_path = Path::new(&crate_dir).join(format!("testbins/autojump/bin/autojump"));
+
+        if !bin_path .exists() {
+            panic!("update submodules before running benches");
+        }
+        bin_path
+            .canonicalize()
+            .unwrap()
+            .to_string_lossy()
+            .to_string()
+    }
+
+    fn init_for(&self, shell: &Shell) -> String {
+        match shell {
+            &Shell::Bash => format!("source '{}'", self.shell_path("bash")),
+            &Shell::Zsh=> format!("source '{}'", self.shell_path("zsh")),
+            &Shell::Conch => unimplemented!(),
+        }
+    }
+
+    fn jump_alias(&self) -> &'static str{
+        "j"
+    }
+}

--- a/tests/src/harness/autojumpers/fasd.rs
+++ b/tests/src/harness/autojumpers/fasd.rs
@@ -40,4 +40,8 @@ eval "$({} --init posix-alias bash-hook)"
             &Shell::Conch => unimplemented!(),
         }
     }
+
+    fn jump_alias(&self) -> &'static str{
+        "z"
+    }
 }

--- a/tests/src/harness/autojumpers/mod.rs
+++ b/tests/src/harness/autojumpers/mod.rs
@@ -1,11 +1,13 @@
 pub mod pazi;
 pub mod fasd;
+pub mod autojump;
 
 use harness::Shell;
 
 pub trait Autojumper {
     fn bin_path(&self) -> String;
     fn init_for(&self, shell: &Shell) -> String;
+    fn jump_alias(&self) -> &'static str;
 }
 
 // None is a non-autojumping shell for benchmarking against.
@@ -18,5 +20,8 @@ impl Autojumper for None {
     }
     fn init_for(&self, _: &Shell) -> String {
         "".to_owned()
+    }
+    fn jump_alias(&self) -> &'static str{
+        panic!("'None' can't jump");
     }
 }

--- a/tests/src/harness/autojumpers/pazi.rs
+++ b/tests/src/harness/autojumpers/pazi.rs
@@ -24,4 +24,8 @@ impl Autojumper for Pazi {
             &Shell::Conch => unimplemented!(),
         }
     }
+
+    fn jump_alias(&self) -> &'static str {
+        "z"
+    }
 }


### PR DESCRIPTION
This is part of #47; adding 'autojump' to the benchmark harness was fairly straightforwards, so this should be easy to review.

I'll redo benchmark results and analysis in a separate PR once I've added the 3rd contestant.