### PR TITLE
README: stick to 80 char columns, move links to end, add closing paren

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 ## What is pazi?
 
-Pazi is an autojump utility. That is to say, pazi remembers visited directories in the past and makes it easier to get back to them.
-A typical use of pazi might look like the following:
+Pazi is an autojump utility. That is to say, pazi remembers visited directories
+in the past and makes it easier to get back to them. A typical use of pazi
+might look like the following:
 
 ```sh
 user@host ~ $ cd go/src/k8s.io/kubernetes
@@ -30,7 +31,7 @@ user@host ~/dev/linux
 First, you need to install the `pazi` binary somewhere in your `$PATH`.
 
 Prebuilt binaries are available on the
-[releases](https://github.com/euank/pazi/releases) page.
+[releases][releases] page.
 
 If you have the rust toolchain installed, you may alternatively compile from
 this repository or run `cargo install pazi`.
@@ -48,17 +49,23 @@ Finally, re-launch the shell and start zapping around :)
 
 ## What makes pazi different from *X*
 
-There are several autojump utilities, including [fasd](https://github.com/clvv/fasd)(or a better maintained [fork](https://github.com/whjvenyl/fasd)), [z](https://github.com/rupa/z), and [autojump](https://github.com/wting/autojump).
+There are several autojump utilities, including [fasd][fasd] (or a better
+maintained [fork][fasd-fork]), [z][z], and [autojump][autojump].
 
-This implementation aims to be faster than any of the others (in no small part due to being in [Rust](https://www.rust-lang.org/en-US/), and also safer than `fasd` and `z` which, being shell-parsers written entirely in shell, are [tricky to get right](https://github.com/clvv/fasd/pull/99).
+This implementation aims to be faster than any of the others (in no small part
+due to being in [Rust][rust]), and also safer than `fasd` and `z` which, being
+shell-parsers written entirely in shell, are [tricky to get right][fasd-pr].
 
 ### So, is it faster?
 
-Pazi is faster than the other autojump implementations it has been benchmarked against by a large margin. The results of these benchmarks are documented [here](docs/Benchmarks.md).
+Pazi is faster than the other autojump implementations it has been benchmarked
+against by a large margin. The results of these benchmarks are documented
+[here][benchmarks].
 
 ## Status
 
-Pazi is currently a work-in-progress. It mostly works, but it's not ready for a 1.0 release yet.
+Pazi is currently a work-in-progress. It mostly works, but it's not ready for a
+1.0 release yet.
 
 The data-format is likely stable (or will be migrated automatically), so now's
 a fine time to try it... but it's quite possible there are bugs and rough
@@ -71,3 +78,12 @@ GPLv3
 ## Contributions
 
 Welcome and encouraged; unfortunately, no contributing.md yet.
+
+[releases]: https://github.com/euank/pazi/releases
+[fasd]: https://github.com/clvv/fasd
+[fasd-fork]: https://github.com/whjvenyl/fasd
+[z]: https://github.com/rupa/z
+[autojump]: https://github.com/wting/autojump
+[rust]: https://www.rust-lang.org/en-US/
+[fasd-pr]: https://github.com/clvv/fasd/pull/99
+[benchmarks]: docs/Benchmarks.md


### PR DESCRIPTION
I noticed a missing parenthesis in the README, made a fork to fix it, and upon seeing the unrendered markdown got a tad carried away.

There was a missing parenthesis under "What makes pazi different from
*X*". Add it.

URLs mixed inline with human-readable text can reduce readability of the
unrendered markdown. Move URLs to references at the end of the document.

The README was a mix of fixed character lines and one paragraph per
line. Reflow all text to be max 80 characters per line.