### PR TITLE
src/interactive: correctly handle empty string

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -217,6 +217,9 @@ fn _main() -> PaziResult {
                     print!("{}", el);
                     res = PaziResult::SuccessDirectory;
                 }
+                Err(interactive::FilterError::NoSelection) => {
+                    return PaziResult::ErrorNoInput;
+                }
                 Err(e) => {
                     println!("{}", e);
                     return PaziResult::Error;

--- a/src/pazi_result.rs
+++ b/src/pazi_result.rs
@@ -16,19 +16,21 @@ macro_rules! EXIT_CODE {
     (SUCCESS) => { 90 };
     (SUCCESS_DIR) => { 91 };
     (ERROR) => { 92 };
+    (ERROR_NO_INPUT) => { 93 };
 }
 
 pub enum PaziResult {
     Success,
     SuccessDirectory,
     Error,
+    ErrorNoInput,
 }
 
 impl PaziResult {
     pub fn exit_code(self) -> i32 {
         match self {
             PaziResult::Success | PaziResult::SuccessDirectory => 0,
-            PaziResult::Error => 1,
+            PaziResult::Error | PaziResult::ErrorNoInput => 1,
         }
     }
 
@@ -37,6 +39,7 @@ impl PaziResult {
             PaziResult::Success => EXIT_CODE!(SUCCESS),
             PaziResult::SuccessDirectory => EXIT_CODE!(SUCCESS_DIR),
             PaziResult::Error => EXIT_CODE!(ERROR),
+            PaziResult::ErrorNoInput => EXIT_CODE!(ERROR_NO_INPUT),
         }
     }
 }

--- a/src/shells/bash.rs
+++ b/src/shells/bash.rs
@@ -39,6 +39,9 @@ pazi_cd() {
     "#,
             EXIT_CODE!(ERROR),
             r#") echo "${res}" && return 1;;
+    "#,
+            EXIT_CODE!(ERROR_NO_INPUT),
+            r#") return 1;;
     *) echo "${res}" && return $ret;;
     esac
 }

--- a/src/shells/zsh.rs
+++ b/src/shells/zsh.rs
@@ -30,6 +30,9 @@ pazi_cd() {
     "#,
             EXIT_CODE!(ERROR),
             r#") echo "${res}" && return 1;;
+    "#,
+            EXIT_CODE!(ERROR_NO_INPUT),
+            r#") return 1;;
     *) echo "${res}" && return $ret;;
     esac
 }


### PR DESCRIPTION
Change interactive.filter to return an Option<String> in the success
case, with Ok(None) representing the user returned an empty string.
Modify main.rs to do nothing when this happens.

Prompted by me seeing the following when I pressed enter without any input on `z -i`:

```
derek@proton ~> z -i ign
pazi_cd:cd:7: no such file or directory: unable to parse selection: cannot parse integer from empty string
```