### PR TITLE
src/shells: Process pazi output after ctrl-c

### DIFF
--- a/src/shells/bash.rs
+++ b/src/shells/bash.rs
@@ -25,10 +25,12 @@ pazi_cd() {
     local res; "#, /* note: this is declared separately because 'local' clobbers pazi's return
     code, see https://lists.gnu.org/archive/html/bug-bash/2010-03/msg00007.html */
             r#"
+    trap 'true' INT
     res="$("#,
             PAZI_EXTENDED_EXIT_CODES_ENV!(),
             r#"=1 pazi --dir "$@")"
     local ret=$?
+    trap - INT
     case $ret in
     "#,
             EXIT_CODE!(SUCCESS),

--- a/src/shells/zsh.rs
+++ b/src/shells/zsh.rs
@@ -16,10 +16,12 @@ add-zsh-hook chpwd __pazi_add_dir
 pazi_cd() {
     if [ "$#" -eq 0 ]; then pazi; return $?; fi
     local res
+    trap 'true' INT
     res="$("#,
             PAZI_EXTENDED_EXIT_CODES_ENV!(),
             r#"=1 pazi --dir "$@")"
     local ret=$?
+    trap - INT
     case $ret in
     "#,
             EXIT_CODE!(SUCCESS),


### PR DESCRIPTION
When a tty receives a `ctrl-c`, it sends SIGINT to the foreground process group (i.e., foreground process and its children). When handling Pazi output, though, we don't want to SIGINT the function running Pazi, just Pazi itself. So, we momentarily ignore SIGINT while Pazi is executing.

We have to reset the signal handler after Pazi completes because the trap settings persist after `pazi_cd()` terminates, at least in `zsh`.

Fixes #54.