### PR TITLE
tests/bench: allow 'wait'ing for forking jumpers

### DIFF
--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -180,8 +180,10 @@ dependencies = [
 name = "pazi-internal"
 version = "0.1.0"
 dependencies = [
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "pazi 0.0.2",
  "pty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "vte 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -15,3 +15,4 @@ rand = "0.3"
 [features]
 default = []
 nightly = []
+cgroups2 = []

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -9,6 +9,8 @@ tempdir = "~0.3"
 pty = "~0.2"
 vte = "~0.3"
 pazi = { path = ".." }
+libc = "~0.2"
+rand = "0.3"
 
 [features]
 default = []

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -26,12 +26,13 @@ fn main() {
             continue;
         }
         let parts = line.split(",").map(|el| el.trim()).collect::<Vec<_>>();
-        if parts.len() != 3 {
-            panic!("each csv line should have 3 parts");
+        if parts.len() != 4 {
+            panic!("each csv line should have 4 parts");
         }
         let bench_name = parts[0].trim();
         let bench_jumpers = parts[1].trim().split(" ");
         let bench_shells = parts[2].trim().split(" ");
+        let bench_waits = parts[3].parse::<bool>().unwrap();
 
         for jumper in bench_jumpers {
             for shell in bench_shells.clone() {
@@ -41,14 +42,19 @@ fn main() {
                     jumper.to_lowercase(),
                     shell.to_lowercase()
                 );
+                let maybe_ignore = if bench_waits {
+                    "\n#[cfg_attr(not(feature = \"cgroups2\"), ignore)]"
+                } else {
+                    ""
+                };
                 code += format!(
                     r#"
-#[bench]
+#[bench]{4}
 fn {0}(b: &mut Bencher) {{
     {1}(b, &{2}, &Shell::{3});
 }}
 "#,
-                    &fn_name, &bench_name, &jumper, &shell
+                    &fn_name, &bench_name, &jumper, &shell, maybe_ignore,
                 ).as_str();
             }
         }

--- a/tests/src/bench.rs
+++ b/tests/src/bench.rs
@@ -72,7 +72,7 @@ fn jump_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
 fn jump_large_db_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
     let tmpdir = TempDir::new("pazi_bench").unwrap();
     let root = tmpdir.path();
-    let mut h = HarnessBuilder::new(&root, jumper, shell).finish();
+    let mut h = HarnessBuilder::new(&root, jumper, shell).cgroup(true).finish();
     let dirp = root.join("tmp_target");
     let dir = dirp.to_str().unwrap();
 
@@ -81,10 +81,12 @@ fn jump_large_db_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
         let dirn = root.join(format!("tmp{}", i));
         h.create_dir(&dirn.to_string_lossy());
         h.visit_dir(&dirn.to_string_lossy());
+        h.wait_children();
     }
 
     h.create_dir(&dir);
     h.visit_dir(&dir);
+    h.wait_children();
 
     b.iter(move || {
         assert_eq!(&h.jump("tmp_target"), &dir);

--- a/tests/src/bench.rs
+++ b/tests/src/bench.rs
@@ -2,13 +2,13 @@ extern crate tempdir;
 extern crate test;
 
 use tempdir::TempDir;
-use harness::{Autojumper, Fasd, Harness, NoJumper, Pazi, Shell, Autojump};
+use harness::{Autojumper, Fasd, HarnessBuilder, NoJumper, Pazi, Shell, Autojump};
 use self::test::Bencher;
 
 fn cd_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
     let tmpdir = TempDir::new("pazi_bench").unwrap();
     let root = tmpdir.path();
-    let mut h = Harness::new(&root, jumper, shell);
+    let mut h = HarnessBuilder::new(&root, jumper, shell).finish();
     let dir1p = root.join("tmp1");
     let dir2p = root.join("tmp2");
     let dir1 = dir1p.to_str().unwrap();
@@ -28,15 +28,41 @@ fn cd_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
     });
 }
 
+fn cd_bench_sync(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
+    let tmpdir = TempDir::new("pazi_bench").unwrap();
+    let root = tmpdir.path();
+    let mut h = HarnessBuilder::new(&root, jumper, shell).cgroup(true).finish();
+    let dir1p = root.join("tmp1");
+    let dir2p = root.join("tmp2");
+    let dir1 = dir1p.to_str().unwrap();
+    let dir2 = dir2p.to_str().unwrap();
+
+    h.create_dir(&dir1);
+    h.create_dir(&dir2);
+
+    // ensure we hit different directories on adjacent iterations; autojumpers may validly avoid
+    // doing work on 'cd .'.
+    let mut iter = 0;
+
+    b.iter(move || {
+        let dir = if iter % 2 == 0 { &dir1 } else { &dir2 };
+        iter += 1;
+        h.visit_dir(dir);
+        h.wait_children();
+        true
+    });
+}
+
 fn jump_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
     let tmpdir = TempDir::new("pazi_bench").unwrap();
     let root = tmpdir.path();
-    let mut h = Harness::new(&root, jumper, shell);
+    let mut h = HarnessBuilder::new(&root, jumper, shell).cgroup(true).finish();
     let dir1p = root.join("tmp1");
     let dir1 = dir1p.to_str().unwrap();
 
     h.create_dir(&dir1);
     h.visit_dir(&dir1);
+    h.wait_children();
 
     b.iter(move || {
         assert_eq!(&h.jump("tmp1"), dir1);
@@ -46,7 +72,7 @@ fn jump_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
 fn jump_large_db_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
     let tmpdir = TempDir::new("pazi_bench").unwrap();
     let root = tmpdir.path();
-    let mut h = Harness::new(&root, jumper, shell);
+    let mut h = HarnessBuilder::new(&root, jumper, shell).finish();
     let dirp = root.join("tmp_target");
     let dir = dirp.to_str().unwrap();
 
@@ -68,7 +94,7 @@ fn jump_large_db_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
 fn cd_50_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
     let tmpdir = TempDir::new("pazi_bench").unwrap();
     let root = tmpdir.path();
-    let mut h = Harness::new(&root, jumper, shell);
+    let mut h = HarnessBuilder::new(&root, jumper, shell).finish();
     let dirs = (0..50)
         .map(|num| format!("{}/dir{}", root.to_str().unwrap(), num))
         .collect::<Vec<_>>();

--- a/tests/src/benches.csv
+++ b/tests/src/benches.csv
@@ -7,6 +7,7 @@
 # 
 # The generated benchmarks will test all combinations j * s for that function.
 cd_bench, NoJumper Pazi Fasd Autojump, Zsh Bash
+cd_bench_sync, NoJumper Pazi Fasd Autojump, Zsh Bash
 cd_50_bench, NoJumper Pazi Fasd Autojump, Zsh Bash
 jump_bench, Pazi Fasd Autojump, Zsh Bash
 jump_large_db_bench, Pazi Fasd Autojump, Zsh Bash

--- a/tests/src/benches.csv
+++ b/tests/src/benches.csv
@@ -4,10 +4,11 @@
 # 1. The name of the benchmark function to run
 # 2. A space-separated list of "Autojumper"s, 'j'
 # 3. A space-separated list of shells, 's'
+# 4. A bool indicating if it needs cgroups2 to run
 # 
 # The generated benchmarks will test all combinations j * s for that function.
-cd_bench, NoJumper Pazi Fasd Autojump, Zsh Bash
-cd_bench_sync, NoJumper Pazi Fasd Autojump, Zsh Bash
-cd_50_bench, NoJumper Pazi Fasd Autojump, Zsh Bash
-jump_bench, Pazi Fasd Autojump, Zsh Bash
-jump_large_db_bench, Pazi Fasd Autojump, Zsh Bash
+cd_bench, NoJumper Pazi Fasd Autojump, Zsh Bash, false
+cd_bench_sync, NoJumper Pazi Fasd Autojump, Zsh Bash, true
+cd_50_bench, NoJumper Pazi Fasd Autojump, Zsh Bash, false
+jump_bench, Pazi Fasd Autojump, Zsh Bash, true
+jump_large_db_bench, Pazi Fasd Autojump, Zsh Bash, true

--- a/tests/src/harness/shells.rs
+++ b/tests/src/harness/shells.rs
@@ -2,12 +2,16 @@ use std::path::Path;
 use harness::autojumpers::Autojumper;
 use std::fs;
 use std::io::Write;
-use std::process::Command;
 
 pub enum Shell {
     Bash,
     Zsh,
     #[allow(dead_code)] Conch,
+}
+
+pub struct ShellCmd<'a> {
+    pub cmd: &'a str,
+    pub env: Vec<(&'a str, String)>,
 }
 
 impl Shell {
@@ -69,10 +73,10 @@ export PATH=$PATH:$(dirname "{0}")
             .unwrap();
     }
 
-    pub fn command(&self, root: &Path) -> Command {
-        let mut cmd = Command::new(self.name());
-        cmd.env_clear();
-        cmd.env("HOME", root.join("home/pazi"));
-        cmd
+    pub fn command(&self, root: &Path) -> ShellCmd {
+        ShellCmd {
+            cmd: self.name(),
+            env: vec![("HOME", root.join("home/pazi").to_string_lossy().to_string())],
+        }
     }
 }

--- a/tests/src/harness/testshell/mod.rs
+++ b/tests/src/harness/testshell/mod.rs
@@ -1,20 +1,37 @@
 extern crate pty;
 extern crate vte;
+extern crate libc;
+extern crate rand;
 
 use std::os::unix::process::CommandExt;
 use std::process::Command;
+use std::path::Path;
+use std::fs;
 use std::io::Read;
 use std::io::Write;
 use std::time::Duration;
 use std::sync::mpsc;
 use std::thread;
 
+use self::rand::Rng;
+
+use super::shells;
+
+#[derive(Clone)]
+struct CgroupMetadata {
+    slice: String,
+    scope: String,
+}
+
 pub struct TestShell {
     // fork is here for lifetime reasons; can't drop it until the pty is done
     #[allow(unused)] fork: pty::fork::Fork,
     pty: pty::fork::Master,
+    pid: libc::pid_t,
     output: mpsc::Receiver<String>,
     eof: mpsc::Receiver<()>,
+    // cgroup, if set, is the cgroup this test shell should run within
+    cgroup: Option<CgroupMetadata>,
 }
 
 // VTEData is to handle lines after the mess of vte terminal stuff.
@@ -109,23 +126,68 @@ impl vte::Perform for VTEData {
 }
 
 impl TestShell {
-    // TODO pattern instead of regex once that's stable
     // new creates a new testshell. It is assumed that the passed in command is for a posix-ish
     // shell. The shell should print output generally line-by-line and after executing a command,
     // it should print the PS1 variable.
     // This PS1 variable is used to determine when commands have executed, so no commands run in
     // this testshell may print the PS1 value.
     // Note: this command does fork off a child. There are dragons. Handle with care.
-    pub fn new(mut cmd: Command, ps1: &str) -> Self {
-        cmd.env("PS1", ps1);
+    pub fn new(cmd: shells::ShellCmd, ps1: &str) -> Self {
+        Self::new_internal(cmd, ps1, None)
+    }
+    pub fn new_in_cgroup(cmd: shells::ShellCmd, ps1: &str, cgroup: &str) -> Self {
+        Self::new_internal(cmd, ps1, Some(cgroup))
+    }
+
+    fn new_internal(cmd: shells::ShellCmd, ps1: &str, cgroup: Option<&str>) -> Self {
+        let mut cgroupmeta = None;
+        let mut cgcmd = if let Some(cg) = cgroup {
+            if unsafe { libc::geteuid() } != 0 {
+                panic!("cgroup pid tracking requires root");
+            }
+            let scope = format!("test_shell_{}", rand::thread_rng().next_u64());
+            let mut tmpcmd = Command::new("systemd-run");
+            // TODO: use `--user` so this doesn't require root; wait for
+            // https://github.com/systemd/systemd/issues/3388 to be fixed on travis + most linux
+            // distros
+            tmpcmd.args(vec![
+                "--no-ask-password",
+                "--slice",
+                cg,
+                "--quiet",
+                "--scope",
+                "--unit",
+                &scope,
+                "--",
+                cmd.cmd,
+            ]);
+            tmpcmd.env_clear();
+
+            cgroupmeta = Some(CgroupMetadata {
+                slice: cg.to_string(),
+                scope: scope,
+            });
+
+            tmpcmd
+        } else {
+            let mut tmpcmd = Command::new(cmd.cmd);
+            tmpcmd.env_clear();
+            tmpcmd
+        };
+        cgcmd.env("PS1", ps1);
+        for env in cmd.env {
+            cgcmd.env(env.0, env.1);
+        }
         let fork = pty::fork::Fork::from_ptmx().unwrap();
 
+        let child_pid;
         let mut pty = match fork {
             pty::fork::Fork::Child(_) => {
-                let err = cmd.exec();
+                let err = cgcmd.exec();
                 panic!("exec failed: {}", err);
             }
-            pty::fork::Fork::Parent(_, m) => {
+            pty::fork::Fork::Parent(c, m) => {
+                child_pid = c;
                 m.grantpt().unwrap();
                 m.unlockpt().unwrap();
                 m
@@ -204,15 +266,49 @@ impl TestShell {
 
         TestShell {
             fork: fork,
+            pid: child_pid,
             pty: pty,
             eof: eof_got,
             output: command_out,
+            cgroup: cgroupmeta,
         }
     }
 
     pub fn run(&mut self, cmd: &str) -> String {
         self.pty.write(format!("{}\n", cmd).as_bytes()).unwrap();
         self.output.recv_timeout(Duration::from_secs(100)).unwrap()
+    }
+
+    pub fn wait_children(&mut self) {
+        if self.cgroup.is_none() {
+            panic!("can only wait for children on testshells created with cgroups");
+        }
+        let cgmeta = self.cgroup.clone().unwrap();
+        // TODO: don't assume unified
+        let cgprocfile = format!("/sys/fs/cgroup/unified/{}.slice/{}.scope/cgroup.procs", cgmeta.slice, cgmeta.scope);
+
+        let mut output = String::new();
+        let mut pids = Vec::new();
+        loop {
+            let mut f = fs::File::open(Path::new(&cgprocfile)).unwrap();
+            output.truncate(0);
+            pids.truncate(0);
+            f.read_to_string(&mut output).unwrap();
+            for line in output.lines() {
+                let pid = line.parse::<i32>().unwrap();
+                if pid == self.pid {
+                    continue
+                }
+                pids.push(pid);
+            }
+            if pids.len() == 0 {
+                return
+            }
+            unsafe {
+                let mut status = 0;
+                libc::waitpid(pids[0], &mut status, libc::WEXITED);
+            };
+        }
     }
 
     pub fn shutdown(&mut self) {

--- a/tests/src/integ.rs
+++ b/tests/src/integ.rs
@@ -3,7 +3,7 @@ extern crate tempdir;
 
 use integ::pazi::shells::SUPPORTED_SHELLS;
 use tempdir::TempDir;
-use harness::{Fasd, Harness, Pazi, Shell};
+use harness::{Fasd, HarnessBuilder, Pazi, Shell};
 use std::time::Duration;
 use std::thread::sleep;
 
@@ -19,7 +19,7 @@ fn it_jumps() {
 fn it_jumps_shell(shell: &Shell) {
     let tmpdir = TempDir::new("pazi_integ").unwrap();
     let root = tmpdir.path();
-    let mut h = Harness::new(&root, &Pazi, shell);
+    let mut h = HarnessBuilder::new(&root, &Pazi, shell).finish();
     let slash_tmp_path = root.join("tmp");
     let slash_tmp = slash_tmp_path.to_string_lossy();
 
@@ -40,7 +40,7 @@ fn it_jumps_to_exact_directory() {
 fn it_jumps_to_exact_directory_shell(shell: &Shell) {
     let tmpdir = TempDir::new("pazi_integ").unwrap();
     let root = tmpdir.path();
-    let mut h = Harness::new(&root, &Pazi, shell);
+    let mut h = HarnessBuilder::new(&root, &Pazi, shell).finish();
     let slash_tmp_path = root.join("tmp");
     let slash_tmp = slash_tmp_path.to_string_lossy();
     let unvisited_dir_path = slash_tmp_path.join("asdf");
@@ -63,7 +63,7 @@ fn it_jumps_to_more_frecent_items() {
 fn it_jumps_to_more_frecent_items_shell(shell: &Shell) {
     let tmpdir = TempDir::new("pazi_integ").unwrap();
     let root = tmpdir.path();
-    let mut h = Harness::new(&root, &Pazi, shell);
+    let mut h = HarnessBuilder::new(&root, &Pazi, shell).finish();
     let a_dir_path = root.join("a/tmp");
     let b_dir_path = root.join("b/tmp");
     let a_dir = a_dir_path.to_string_lossy();
@@ -102,7 +102,7 @@ fn it_imports_from_fasd_shell(shell: &Shell) {
     let root = tmpdir.path();
 
     {
-        let mut fasd = Harness::new(&root, &Fasd, shell);
+        let mut fasd = HarnessBuilder::new(&root, &Fasd, shell).finish();
         fasd.create_dir(&root.join("tmp").to_string_lossy());
         // visit twice because fasd uses 'history 1' to do stuff in bash... which means yeah, it's
         // 1-command-delayed
@@ -111,7 +111,7 @@ fn it_imports_from_fasd_shell(shell: &Shell) {
     }
 
     {
-        let mut h = Harness::new(&root, &Pazi, shell);
+        let mut h = HarnessBuilder::new(&root, &Pazi, shell).finish();
         assert_eq!(
             h.run_cmd("pazi import fasd").trim(),
             "imported 1 items from fasd (out of 1 in its db)"
@@ -132,7 +132,7 @@ fn it_ignores_dead_dirs_on_cd() {
 fn it_ignores_dead_dirs_on_cd_shell(shell: &Shell) {
     let tmpdir = TempDir::new("pazi_integ").unwrap();
     let root = tmpdir.path();
-    let mut h = Harness::new(&root, &Pazi, shell);
+    let mut h = HarnessBuilder::new(&root, &Pazi, shell).finish();
 
     h.create_dir(&root.join("1/tmp").to_string_lossy());
     h.create_dir(&root.join("2/tmp").to_string_lossy());
@@ -159,7 +159,7 @@ fn it_prints_list_on_lonely_z() {
 fn it_prints_list_on_lonely_z_shell(shell: &Shell) {
     let tmpdir = TempDir::new("pazi_integ").unwrap();
     let root = tmpdir.path();
-    let mut h = Harness::new(&root, &Pazi, shell);
+    let mut h = HarnessBuilder::new(&root, &Pazi, shell).finish();
 
     h.create_dir(&root.join("1/tmp").to_string_lossy());
     h.create_dir(&root.join("2/tmp").to_string_lossy());
@@ -181,7 +181,7 @@ fn it_handles_existing_bash_prompt_command() {
     let prompt_cmd = r#"
 PROMPT_COMMAND='printf "\033k%s@%s:%s\033\\" "${USER}" "${HOSTNAME%%.*}" "${PWD/#$HOME/\~}"'
 "#;
-    let mut h = Harness::new_with_preinit(&root, &Pazi, &Shell::Bash, prompt_cmd);
+    let mut h = HarnessBuilder::new(&root, &Pazi, &Shell::Bash).preinit(prompt_cmd).finish();
     let slash_tmp_path = root.join("tmp");
     let slash_tmp = slash_tmp_path.to_string_lossy();
 
@@ -202,7 +202,7 @@ fn it_handles_help_output() {
 fn it_handles_help_output_shell(shell: &Shell) {
     let tmpdir = TempDir::new("pazi_integ").unwrap();
     let root = tmpdir.path();
-    let mut h = Harness::new(&root, &Pazi, shell);
+    let mut h = HarnessBuilder::new(&root, &Pazi, shell).finish();
     let help1 = h.run_cmd("pazi --help && echo $?");
     let help2 = h.run_cmd("z -h && echo $?");
     let help3 = h.run_cmd("z --help && echo $?");
@@ -223,7 +223,7 @@ fn it_handles_things_that_look_sorta_like_init_but_not_really() {
 fn it_handles_things_that_look_sorta_etc_shell(shell: &Shell) {
     let tmpdir = TempDir::new("pazi_integ").unwrap();
     let root = tmpdir.path();
-    let mut h = Harness::new(&root, &Pazi, shell);
+    let mut h = HarnessBuilder::new(&root, &Pazi, shell).finish();
     let igni = root.join("ignition").into_os_string().into_string().unwrap();
 
     h.create_dir(&igni);


### PR DESCRIPTION
This implements a way for benchmarks to indicate that the testshell
should wait for any forked processes to end.

This is helpful for `z` and `autojump`, which add directories by forking
off into the background.

This will allow benchmarking the speed of those operations, and to make
the benchmarks not flaky (e.g. rcd + jump can flake without a wait in
between).

The implementation is done by using cgroups to keep track of pids,
assuming a shell during normal operation will only have one pid, and
then going from there.

There are a cople caveats:
1. This requires cgroups-v2 or hybrid for tracking processes
   (cgroup.procs) vs threads.
1. The overhead introduced by this is difficult to measure perfectly; it
   has no significant impact in the case where children aren't forked,
   but when children are, I have no baseline to compare with.

This commit also does a bit of other cleanup, such as switching the
harness to a builder method.