### PR TITLE
 benches: add 'z' to benches

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "tests/testbins/autojump"]
 	path = tests/testbins/autojump
 	url = https://github.com/wting/autojump
+[submodule "tests/testbins/z"]
+	path = tests/testbins/z
+	url = https://github.com/rupa/z

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -29,33 +29,35 @@ fn main() {
         if parts.len() != 4 {
             panic!("each csv line should have 4 parts");
         }
-        let bench_name = parts[0].trim();
+        let bench_names = parts[0].trim().split(" ");
         let bench_jumpers = parts[1].trim().split(" ");
         let bench_shells = parts[2].trim().split(" ");
         let bench_waits = parts[3].parse::<bool>().unwrap();
 
-        for jumper in bench_jumpers {
-            for shell in bench_shells.clone() {
-                let fn_name = format!(
-                    "{}_{}_{}",
-                    bench_name,
-                    jumper.to_lowercase(),
-                    shell.to_lowercase()
-                );
-                let maybe_ignore = if bench_waits {
-                    "\n#[cfg_attr(not(feature = \"cgroups2\"), ignore)]"
-                } else {
-                    ""
-                };
-                code += format!(
-                    r#"
-#[bench]{4}
-fn {0}(b: &mut Bencher) {{
-    {1}(b, &{2}, &Shell::{3});
-}}
-"#,
-                    &fn_name, &bench_name, &jumper, &shell, maybe_ignore,
-                ).as_str();
+        for bench_name in bench_names {
+            for jumper in bench_jumpers.clone() {
+                for shell in bench_shells.clone() {
+                    let fn_name = format!(
+                        "{}_{}_{}",
+                        bench_name,
+                        jumper.to_lowercase(),
+                        shell.to_lowercase()
+                    );
+                    let maybe_ignore = if bench_waits {
+                        "\n#[cfg_attr(not(feature = \"cgroups2\"), ignore)]"
+                    } else {
+                        ""
+                    };
+                    code += format!(
+                        r#"
+    #[bench]{4}
+    fn {0}(b: &mut Bencher) {{
+        {1}(b, &{2}, &Shell::{3});
+    }}
+    "#,
+                        &fn_name, &bench_name, &jumper, &shell, maybe_ignore,
+                    ).as_str();
+                }
             }
         }
     }

--- a/tests/src/bench.rs
+++ b/tests/src/bench.rs
@@ -2,7 +2,7 @@ extern crate tempdir;
 extern crate test;
 
 use tempdir::TempDir;
-use harness::{Autojumper, Fasd, HarnessBuilder, NoJumper, Pazi, Shell, Autojump};
+use harness::{Autojumper, Fasd, Z, HarnessBuilder, NoJumper, Pazi, Shell, Autojump};
 use self::test::Bencher;
 
 fn cd_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {

--- a/tests/src/benches.csv
+++ b/tests/src/benches.csv
@@ -7,8 +7,8 @@
 # 4. A bool indicating if it needs cgroups2 to run
 # 
 # The generated benchmarks will test all combinations j * s for that function.
-cd_bench, NoJumper Pazi Fasd Autojump, Zsh Bash, false
-cd_bench_sync, NoJumper Pazi Fasd Autojump, Zsh Bash, true
-cd_50_bench, NoJumper Pazi Fasd Autojump, Zsh Bash, false
-jump_bench, Pazi Fasd Autojump, Zsh Bash, true
-jump_large_db_bench, Pazi Fasd Autojump, Zsh Bash, true
+cd_bench, NoJumper Pazi Fasd Autojump Z, Zsh Bash, false
+cd_bench_sync, NoJumper Pazi Fasd Autojump Z, Zsh Bash, true
+cd_50_bench, NoJumper Pazi Fasd Autojump Z, Zsh Bash, false
+jump_bench, Pazi Fasd Autojump Z, Zsh Bash, true
+jump_large_db_bench, Pazi Fasd Autojump Z, Zsh Bash, true

--- a/tests/src/benches.csv
+++ b/tests/src/benches.csv
@@ -7,8 +7,14 @@
 # 4. A bool indicating if it needs cgroups2 to run
 # 
 # The generated benchmarks will test all combinations j * s for that function.
-cd_bench, NoJumper Pazi Fasd Autojump Z, Zsh Bash, false
+#
+# Note: z is left out of benches with zsh because it frequently fails and prints:
+# > mv: cannot stat \'/tmp/pazi_bench.yyFRBViCftwU/home/pazi/.z.537\': No such file or directory
+# It works fine in bash, and the cd bench works, but for some reason the jump
+# one in zsh constantly hits that. I think it has to do with how $RANDOM works
+# in zsh.
+cd_bench, NoJumper Pazi Fasd Autojump, Zsh Bash, false
+cd_bench, Z, Bash, false
 cd_bench_sync, NoJumper Pazi Fasd Autojump Z, Zsh Bash, true
-cd_50_bench, NoJumper Pazi Fasd Autojump Z, Zsh Bash, false
-jump_bench, Pazi Fasd Autojump Z, Zsh Bash, true
-jump_large_db_bench, Pazi Fasd Autojump Z, Zsh Bash, true
+jump_bench jump_large_db_bench, Pazi Fasd Autojump, Zsh Bash, true
+jump_bench jump_large_db_bench, Z, Bash, true

--- a/tests/src/harness/autojumpers/mod.rs
+++ b/tests/src/harness/autojumpers/mod.rs
@@ -1,6 +1,7 @@
 pub mod pazi;
 pub mod fasd;
 pub mod autojump;
+pub mod z;
 
 use harness::Shell;
 

--- a/tests/src/harness/autojumpers/z.rs
+++ b/tests/src/harness/autojumpers/z.rs
@@ -1,0 +1,38 @@
+use super::Autojumper;
+use harness::Shell;
+use std::env;
+use std::path::Path;
+
+pub struct Z;
+
+impl Autojumper for Z {
+    fn bin_path(&self) -> String {
+        let crate_dir = env::var("CARGO_MANIFEST_DIR").expect("build with cargo");
+        let bin_path = Path::new(&crate_dir).join(format!("testbins/z/z.sh"));
+
+        if !bin_path.exists() {
+            panic!("update submodules before running benches");
+        }
+        bin_path
+            .canonicalize()
+            .unwrap()
+            .to_string_lossy()
+            .to_string()
+    }
+
+    fn init_for(&self, shell: &Shell) -> String {
+        match shell {
+            &Shell::Bash | &Shell::Zsh => format!(
+                r#"
+. "{}"
+"#,
+                self.bin_path()
+            ),
+            &Shell::Conch => unimplemented!(),
+        }
+    }
+
+    fn jump_alias(&self) -> &'static str{
+        "z"
+    }
+}

--- a/tests/src/harness/mod.rs
+++ b/tests/src/harness/mod.rs
@@ -10,6 +10,7 @@ pub use self::shells::Shell;
 pub use self::autojumpers::Autojumper;
 pub use self::autojumpers::pazi::Pazi;
 pub use self::autojumpers::fasd::Fasd;
+pub use self::autojumpers::z::Z;
 pub use self::autojumpers::autojump::Autojump;
 pub use self::autojumpers::None as NoJumper;
 


### PR DESCRIPTION
`z` is actually quite fast. It's still slightly slower than pazi, but it's scarily close.

```
test bench::cd_bench_autojump_bash            ... bench:  19,589,749 ns/iter (+/- 10,152,476)
test bench::cd_bench_autojump_zsh             ... bench:  21,986,256 ns/iter (+/- 10,536,365)
test bench::cd_bench_fasd_bash                ... bench:  15,264,866 ns/iter (+/- 4,113,044)
test bench::cd_bench_fasd_zsh                 ... bench:  13,967,354 ns/iter (+/- 1,495,894)
test bench::cd_bench_nojumper_bash            ... bench:      94,704 ns/iter (+/- 10,146)
test bench::cd_bench_nojumper_zsh             ... bench:      40,872 ns/iter (+/- 8,339)
test bench::cd_bench_pazi_bash                ... bench:   1,142,437 ns/iter (+/- 45,770)
test bench::cd_bench_pazi_zsh                 ... bench:   1,065,292 ns/iter (+/- 44,725)
test bench::cd_bench_sync_autojump_bash       ... bench:  55,492,148 ns/iter (+/- 7,574,749)
test bench::cd_bench_sync_autojump_zsh        ... bench:  55,619,760 ns/iter (+/- 3,962,816)
test bench::cd_bench_sync_fasd_bash           ... bench:  15,136,087 ns/iter (+/- 392,640)
test bench::cd_bench_sync_fasd_zsh            ... bench:  14,098,202 ns/iter (+/- 3,418,708)
test bench::cd_bench_sync_nojumper_bash       ... bench:     100,944 ns/iter (+/- 28,180)
test bench::cd_bench_sync_nojumper_zsh        ... bench:      40,626 ns/iter (+/- 11,104)
test bench::cd_bench_sync_pazi_bash           ... bench:   1,153,429 ns/iter (+/- 168,226)
test bench::cd_bench_sync_pazi_zsh            ... bench:   1,110,109 ns/iter (+/- 252,931)
test bench::cd_bench_sync_z_bash              ... bench:   3,635,950 ns/iter (+/- 1,416,142)
test bench::cd_bench_sync_z_zsh               ... bench:   3,309,784 ns/iter (+/- 1,145,567)
test bench::cd_bench_z_bash                   ... bench:   1,261,883 ns/iter (+/- 577,956)
test bench::jump_bench_autojump_bash          ... bench:  59,831,630 ns/iter (+/- 2,751,177)
test bench::jump_bench_autojump_zsh           ... bench:  57,806,548 ns/iter (+/- 2,293,375)
test bench::jump_bench_fasd_bash              ... bench:  31,863,379 ns/iter (+/- 2,480,926)
test bench::jump_bench_fasd_zsh               ... bench:  30,331,267 ns/iter (+/- 710,592)
test bench::jump_bench_pazi_bash              ... bench:   1,256,484 ns/iter (+/- 40,560)
test bench::jump_bench_pazi_zsh               ... bench:   2,092,546 ns/iter (+/- 72,154)
test bench::jump_bench_z_bash                 ... bench:   3,719,069 ns/iter (+/- 547,536)
test bench::jump_large_db_bench_autojump_bash ... bench: 103,008,161 ns/iter (+/- 13,729,874)
test bench::jump_large_db_bench_autojump_zsh  ... bench:  99,094,920 ns/iter (+/- 10,234,532)
test bench::jump_large_db_bench_fasd_bash     ... bench:  35,777,551 ns/iter (+/- 611,777)
test bench::jump_large_db_bench_fasd_zsh      ... bench:  35,020,210 ns/iter (+/- 2,236,522)
test bench::jump_large_db_bench_pazi_bash     ... bench:  18,817,642 ns/iter (+/- 547,314)
test bench::jump_large_db_bench_pazi_zsh      ... bench:  23,327,924 ns/iter (+/- 642,933)
test bench::jump_large_db_bench_z_bash        ... bench:  19,685,918 ns/iter (+/- 3,440,844)
```