### PR TITLE
Lazy pruning of deleted directories

### DIFF
--- a/src/frecency.rs
+++ b/src/frecency.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::f64;
@@ -101,10 +102,7 @@ where
             .iter()
             .map(|(ref t, f)| (*t, f.clone()))
             .collect::<Vec<_>>();
-        v.sort_unstable_by(|&(_, rhs), &(_, lhs)| {
-            lhs.partial_cmp(&rhs)
-                .expect(&format!("{} could not be compared to {}", lhs, rhs))
-        });
+        v.sort_unstable_by(descending_frecency);
         v
     }
 
@@ -131,6 +129,13 @@ where
             })
             .collect()
     }
+}
+
+pub fn descending_frecency<T>(lhs: &(T, f64), rhs: &(T, f64)) -> Ordering {
+    // NaN shouldn't happen
+    rhs.1
+        .partial_cmp(&lhs.1)
+        .expect(&format!("{} could not be compared to {}", lhs.1, rhs.1))
 }
 
 #[cfg(test)]

--- a/src/frecency.rs
+++ b/src/frecency.rs
@@ -108,20 +108,8 @@ where
         v
     }
 
-    pub fn retain<F>(&mut self, mut pred: F) -> bool
-    where
-        F: FnMut(&T) -> bool,
-    {
-        let mut any_removed = false;
-        self.frecency.retain(|k, _| {
-            if pred(k) {
-                true
-            } else {
-                any_removed = true;
-                false
-            }
-        });
-        any_removed
+    pub fn remove(&mut self, key: &T) -> Option<f64> {
+        self.frecency.remove(key)
     }
 
     pub fn normalized_frecency(&self) -> Vec<(&T, f64)> {

--- a/src/frecency.rs
+++ b/src/frecency.rs
@@ -102,7 +102,7 @@ where
             .iter()
             .map(|(ref t, f)| (*t, f.clone()))
             .collect::<Vec<_>>();
-        v.sort_unstable_by(descending_frecency);
+        v.sort_by(descending_frecency);
         v
     }
 
@@ -117,7 +117,7 @@ where
         }
         let min = items[items.len() - 1].1;
         let max = items[0].1;
-        items
+        let mut items: Vec<_> = items
             .into_iter()
             .map(|(s, v)| {
                 let normalized = (v - min) / (max - min);
@@ -127,7 +127,9 @@ where
                     (s, normalized)
                 }
             })
-            .collect()
+            .collect();
+        items.sort_by(descending_frecency);
+        items
     }
 }
 

--- a/src/frecent_paths.rs
+++ b/src/frecent_paths.rs
@@ -1,7 +1,7 @@
 // frecent_paths is a specialization of frecency that understands the semantics of stored paths.
 // It does things like the messyness of checking for a directory's existence and such.
 
-use frecency::Frecency;
+use frecency::{descending_frecency, Frecency};
 use std::path::{Path, PathBuf};
 use std::collections::HashMap;
 use std::fs;
@@ -105,13 +105,7 @@ impl PathFrecency {
             .iter()
             .map(|&(p, f)| (p.clone(), f.clone()))
             .collect::<Vec<_>>();
-        items.sort_by(|lhs, rhs| {
-            // NaN shouldn't happen
-            lhs.1
-                .partial_cmp(&rhs.1)
-                .expect(&format!("{} could not be compared to {}", lhs.1, rhs.1))
-        });
-
+        items.sort_by(descending_frecency);
         items
     }
 
@@ -191,12 +185,7 @@ impl PathFrecency {
         }
 
         let mut deduped = dedupe_map.into_iter().collect::<Vec<_>>();
-        deduped.sort_by(|lhs, rhs| {
-            // NaN shouldn't happen
-            rhs.1
-                .partial_cmp(&lhs.1)
-                .expect(&format!("{} could not be compared to {}", lhs.1, rhs.1))
-        });
+        deduped.sort_by(descending_frecency);
 
         debug!("{}",
                deduped.iter()

--- a/src/frecent_paths.rs
+++ b/src/frecent_paths.rs
@@ -162,9 +162,9 @@ impl PathFrecency {
             .iter()
             .flat_map(|item| {
                 matchers.iter()
-                    .filter_map(move |m| match m.matches(&item.0, filter) {
-                        Some(v) => Some((item.0.to_owned(), v * 0.8 + item.1 * 0.2)),
-                        None => None,
+                    .filter_map(move |m| {
+                        m.matches(&item.0, filter)
+                            .map(|v| (item.0.to_owned(), v * 0.8 + item.1 * 0.2))
                     })
             })
             .collect::<Vec<_>>();

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -8,12 +8,10 @@ use std::fs;
 use std::thread;
 use chan_signal;
 use chan;
-use frecent_paths::PathIter;
 
-pub fn filter<'a>(opts_iter: PathIter<'a>,
-                  stdin: Stdin,
-                  stdout: fs::File)
-                  -> Result<String, FilterError> {
+pub fn filter<I>(opts_iter: I, stdin: Stdin, stdout: fs::File) -> Result<String, FilterError>
+    where I: Iterator<Item = (String, f64)>
+{
     // So, this is a massive abstraction leak, but unix signals are icky so it's not really
     // surprising.
     // Because we're popping over to an alternative screen buffer, we need to restore the teriminal

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -8,12 +8,12 @@ use std::fs;
 use std::thread;
 use chan_signal;
 use chan;
+use frecent_paths::PathIter;
 
-pub fn filter<'a>(
-    opts: Vec<(&'a String, f64)>,
-    stdin: Stdin,
-    stdout: fs::File,
-) -> Result<String, FilterError> {
+pub fn filter<'a>(opts_iter: PathIter<'a>,
+                  stdin: Stdin,
+                  stdout: fs::File)
+                  -> Result<String, FilterError> {
     // So, this is a massive abstraction leak, but unix signals are icky so it's not really
     // surprising.
     // Because we're popping over to an alternative screen buffer, we need to restore the teriminal
@@ -29,6 +29,13 @@ pub fn filter<'a>(
     let (suser_input, ruser_input) = chan::sync(0);
     // Wait for a signal or for the user to select a choice.
     write!(alt, "{}{}", clear::All, cursor::Goto(1, 1))?;
+
+    let opts = {
+        let mut opts = opts_iter.collect::<Vec<_>>();
+        opts.reverse();
+        opts
+    };
+
     for i in 0..opts.len() {
         write!(alt, "{}\t{}\t{}\n", opts.len() - i, opts[i].1, opts[i].0)?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,7 +201,7 @@ fn _main() -> PaziResult {
         }
     } else if flags.is_present("dir") {
         // Safe to unwrap because 'dir' requires 'dir_target'
-        let matches = match flags.value_of("dir_target") {
+        let mut matches = match flags.value_of("dir_target") {
             Some(to) => {
                 env::current_dir()
                     .map(|cwd| {
@@ -212,10 +212,6 @@ fn _main() -> PaziResult {
             }
             None => frecency.items_with_frecency(),
         };
-        if matches.len() == 0 {
-            return PaziResult::Error;
-        }
-
         if flags.is_present("interactive") {
             let stdout = termion::get_tty().unwrap();
             match interactive::filter(matches, std::io::stdin(), stdout) {
@@ -231,10 +227,11 @@ fn _main() -> PaziResult {
                     return PaziResult::Error;
                 }
             }
-        } else {
-            // unwrap is safe because of the 'matches.len() == 0' check above.
-            print!("{}", matches.last().unwrap().0);
+        } else if let Some((path, _)) = matches.next() {
+            print!("{}", path);
             res = PaziResult::SuccessDirectory;
+        } else {
+            res = PaziResult::Error;
         }
     } else if flags.value_of("dir_target") != None {
         // Something got interpreted as 'dir_target' even though this wasn't in '--dir'


### PR DESCRIPTION
`frecency` changes:
- Always returns results sorted by most to least frecent
- Always returns references to the path strings it owns

`frecent_paths` changes:
- Paths are iterated over in order from most to least frecent
- Always returns an iterator over paths that it owns
- Paths are copied at most once

Benchmarks (Core 2 Duo, spinning rust): https://p.brod.es/#/view/Skxq8Q_j/I80JjCqchcxH4fC3y.updmHMMhzf5lg0

Possible improvements:
- Benchmarking jump where paths must be removed vs jump where paths may not be removed
- Allocating path strings in an arena so that no copying is needed

Personally, I'm happy with this, but I'd like to clean up the git history before merging.

Closes #32.