### PR TITLE
 main: move 'jump' and 'visit' to subcommands 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,20 @@ fn main() {
     }
 }
 
+enum PaziSubcommand {
+    Import,
+    Init,
+}
+
+impl PaziSubcommand {
+    fn as_str(&self) -> &'static str {
+        match self {
+            PaziSubcommand::Import => "import",
+            PaziSubcommand::Init => "init",
+        }
+    }
+}
+
 fn _main() -> PaziResult {
     let flags = App::new("pazi")
         .about("A fast autojump tool")
@@ -59,7 +73,7 @@ fn _main() -> PaziResult {
                 .env("PAZI_DEBUG"),
         )
         .subcommand(
-            SubCommand::with_name("init")
+            SubCommand::with_name(PaziSubcommand::Init.as_str())
                 .about("Prints intialization logic for the given shell to eval")
                 .usage(format!("pazi init [ {} ]", SUPPORTED_SHELLS.join(" | ")).as_str())
                 .arg(Arg::with_name("shell").help(&format!(
@@ -68,7 +82,7 @@ fn _main() -> PaziResult {
                 ))),
         )
         .subcommand(
-            SubCommand::with_name("import")
+            SubCommand::with_name(PaziSubcommand::Import.as_str())
                 .about("Import from another autojump program")
                 .usage("pazi import fasd")
                 .arg(Arg::with_name("autojumper").help(&format!(
@@ -109,7 +123,7 @@ fn _main() -> PaziResult {
         .group(ArgGroup::with_name("operation").args(&["dir", "add-dir"]))
         .get_matches();
 
-    if let Some(init_matches) = flags.subcommand_matches("init") {
+    if let Some(init_matches) = flags.subcommand_matches(PaziSubcommand::Init.as_str()) {
         match init_matches.value_of("shell") {
             Some(s) => match shells::from_name(s) {
                 Some(s) => {
@@ -150,7 +164,7 @@ fn _main() -> PaziResult {
 
     let mut frecency = PathFrecency::load(&frecency_path);
 
-    if let Some(import_matches) = flags.subcommand_matches("import") {
+    if let Some(import_matches) = flags.subcommand_matches(PaziSubcommand::Import.as_str()) {
         match import_matches.value_of("autojumper") {
             Some("fasd") => match importers::Fasd::import(&mut frecency) {
                 Ok(stats) => match frecency.save_to_disk() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -432,11 +432,6 @@ fn handle_print_frecency(cmd: &ArgMatches) -> PaziResult {
 
     let matches = match cmd.value_of("dir_target") {
         Some(to) => {
-            env::current_dir()
-                .map(|cwd| {
-                    frecency.maybe_add_relative_to(cwd, to);
-                })
-            .unwrap_or(()); // truly ignore failure to get cwd
             frecency.directory_matches(to)
         }
         None => frecency.items_with_frecency(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,6 +142,7 @@ fn _main() -> PaziResult {
         .arg(
             Arg::with_name("add-dir")
                 .help("add a directory to the frecency index")
+                .hidden(true)
                 .long("add-dir")
                 .takes_value(true)
                 .value_name("directory"),
@@ -156,7 +157,7 @@ fn _main() -> PaziResult {
         // 
         // A positional argument was the only way I could figure out to do that without writing
         // more shell in init.
-        .arg(Arg::with_name("dir_target"))
+        .arg(Arg::with_name("dir_target").hidden(true))
         .group(ArgGroup::with_name("operation").args(&["dir", "add-dir"]))
         .get_matches();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,24 +47,15 @@ fn main() {
     }
 }
 
-enum PaziSubcommand {
-    Import,
-    Init,
-    Jump,
-    View,
-    Visit,
-}
-
-impl PaziSubcommand {
-    fn as_str(&self) -> &'static str {
-        match self {
-            PaziSubcommand::Import => "import",
-            PaziSubcommand::Init => "init",
-            PaziSubcommand::Jump => "jump",
-            PaziSubcommand::View => "view",
-            PaziSubcommand::Visit => "visit",
-        }
-    }
+// SUBCOMMAND is a macro-enum of all subcommands.
+// This should be replaced by a normal enum + const "as_str" for each variant once rust stable
+// supports const functions.
+macro_rules! SUBCOMMAND {
+    (Import) => { "import" };
+    (Init) => { "init" };
+    (Jump) => { "jump" };
+    (View) => { "view" };
+    (Visit) => { "visit" };
 }
 
 fn _main() -> PaziResult {
@@ -79,7 +70,7 @@ fn _main() -> PaziResult {
                 .env("PAZI_DEBUG"),
         )
         .subcommand(
-            SubCommand::with_name(PaziSubcommand::Init.as_str())
+            SubCommand::with_name(SUBCOMMAND!(Init))
                 .about("Prints initialization logic for the given shell to eval")
                 .usage(format!("pazi init [ {} ]", SUPPORTED_SHELLS.join(" | ")).as_str())
                 .arg(Arg::with_name("shell").help(&format!(
@@ -88,7 +79,7 @@ fn _main() -> PaziResult {
                 ))),
         )
         .subcommand(
-            SubCommand::with_name(PaziSubcommand::Import.as_str())
+            SubCommand::with_name(SUBCOMMAND!(Import))
                 .about("Import from another autojump program")
                 .usage("pazi import fasd")
                 .arg(Arg::with_name("autojumper").help(&format!(
@@ -96,7 +87,7 @@ fn _main() -> PaziResult {
                 ))),
         )
         .subcommand(
-            SubCommand::with_name(PaziSubcommand::Jump.as_str())
+            SubCommand::with_name(SUBCOMMAND!(Jump))
                 // used by the shell alias internally, it shouldn't be called directly
                 .setting(AppSettings::Hidden)
                 .setting(AppSettings::DisableHelpSubcommand)
@@ -110,7 +101,7 @@ fn _main() -> PaziResult {
                 .arg(Arg::with_name("dir_target"))
         )
         .subcommand(
-            SubCommand::with_name(PaziSubcommand::View.as_str())
+            SubCommand::with_name(SUBCOMMAND!(View))
                 .setting(AppSettings::DisableHelpSubcommand)
                 .about("View the frecency database")
                 .arg(
@@ -119,7 +110,7 @@ fn _main() -> PaziResult {
                 )
         )
         .subcommand(
-            SubCommand::with_name(PaziSubcommand::Visit.as_str())
+            SubCommand::with_name(SUBCOMMAND!(Visit))
                 // used by the shell hooks internally, it shouldn't be called directly
                 .setting(AppSettings::Hidden)
                 .setting(AppSettings::DisableHelpSubcommand)
@@ -182,21 +173,20 @@ fn _main() -> PaziResult {
         }
     }
 
-
     match flags.subcommand() {
-        (name, Some(import)) if name == PaziSubcommand::Import.as_str() => {
+        (SUBCOMMAND!(Import), Some(import)) => {
             return handle_import(import);
         }
-        (name, Some(init)) if name == PaziSubcommand::Init.as_str() => {
+        (SUBCOMMAND!(Init), Some(init)) => {
             return handle_init(init);
         }
-        (name, Some(jump)) if name == PaziSubcommand::Jump.as_str() => {
+        (SUBCOMMAND!(Jump), Some(jump)) => {
             return handle_jump(jump);
         }
-        (name, Some(view)) if name == PaziSubcommand::View.as_str() => {
+        (SUBCOMMAND!(View), Some(view)) => {
             return handle_print_frecency(view);
         }
-        (name, Some(visit)) if name == PaziSubcommand::Visit.as_str() => {
+        (SUBCOMMAND!(Visit), Some(visit)) => {
             return handle_visit(visit);
         }
         unknown => {

--- a/src/shells/bash.rs
+++ b/src/shells/bash.rs
@@ -21,7 +21,7 @@ case \$PROMPT_COMMAND in
 esac
 
 pazi_cd() {
-    if [ "$#" -eq 0 ]; then pazi; return $?; fi
+    if [ "$#" -eq 0 ]; then pazi view; return $?; fi
     local res; "#, /* note: this is declared separately because 'local' clobbers pazi's return
     code, see https://lists.gnu.org/archive/html/bug-bash/2010-03/msg00007.html */
             r#"

--- a/src/shells/bash.rs
+++ b/src/shells/bash.rs
@@ -10,7 +10,7 @@ impl Shell for Bash {
 __pazi_add_dir() {
     # TODO: should pazi keep track of this itself in its datadir?
     if [[ "${__PAZI_LAST_PWD}" != "${PWD}" ]]; then
-        pazi --add-dir "${PWD}"
+        pazi visit "${PWD}"
     fi
     __PAZI_LAST_PWD="${PWD}"
 }
@@ -27,7 +27,7 @@ pazi_cd() {
             r#"
     res="$("#,
             PAZI_EXTENDED_EXIT_CODES_ENV!(),
-            r#"=1 pazi --dir "$@")"
+            r#"=1 pazi jump "$@")"
     local ret=$?
     case $ret in
     "#,

--- a/src/shells/zsh.rs
+++ b/src/shells/zsh.rs
@@ -7,7 +7,7 @@ impl Shell for Zsh {
         concat!(
             r#"
 __pazi_add_dir() {
-    pazi --add-dir "${PWD}"
+    pazi visit "${PWD}"
 }
 
 autoload -Uz add-zsh-hook
@@ -18,7 +18,7 @@ pazi_cd() {
     local res
     res="$("#,
             PAZI_EXTENDED_EXIT_CODES_ENV!(),
-            r#"=1 pazi --dir "$@")"
+            r#"=1 pazi jump "$@")"
     local ret=$?
     case $ret in
     "#,

--- a/src/shells/zsh.rs
+++ b/src/shells/zsh.rs
@@ -14,7 +14,7 @@ autoload -Uz add-zsh-hook
 add-zsh-hook chpwd __pazi_add_dir
 
 pazi_cd() {
-    if [ "$#" -eq 0 ]; then pazi; return $?; fi
+    if [ "$#" -eq 0 ]; then pazi view; return $?; fi
     local res
     res="$("#,
             PAZI_EXTENDED_EXIT_CODES_ENV!(),

--- a/tests/src/integ.rs
+++ b/tests/src/integ.rs
@@ -4,6 +4,7 @@ extern crate tempdir;
 use integ::pazi::shells::SUPPORTED_SHELLS;
 use tempdir::TempDir;
 use harness::{Fasd, HarnessBuilder, Pazi, Shell};
+use std::collections::HashMap;
 use std::time::Duration;
 use std::thread::sleep;
 
@@ -206,28 +207,46 @@ fn it_handles_help_output_shell(shell: &Shell) {
     let help1 = h.run_cmd("pazi --help && echo $?");
     let help2 = h.run_cmd("z -h && echo $?");
     let help3 = h.run_cmd("z --help && echo $?");
-    assert_eq!(help1, help2);
-    assert_eq!(help2, help3);
+    assert!(help1.contains("USAGE:"), help1);
+    assert!(help2.contains("USAGE:"), help2);
     assert!(help1.ends_with("\n0"));
+    assert!(help2.ends_with("\n0"));
+
+    assert_eq!(help2, help3);
 }
 
 // Test for https://github.com/euank/pazi/issues/60
+// and https://github.com/euank/pazi/issues/70
 #[test]
-fn it_handles_things_that_look_sorta_like_init_but_not_really() {
+fn it_handles_things_that_look_like_subcommands() {
     for shell in SUPPORTED_SHELLS.iter() {
         let s = Shell::from_str(shell);
-        it_handles_things_that_look_sorta_etc_shell(&s);
+        it_handles_things_that_look_like_subcommands_shell(&s);
     }
 }
 
-fn it_handles_things_that_look_sorta_etc_shell(shell: &Shell) {
+fn it_handles_things_that_look_like_subcommands_shell(shell: &Shell) {
     let tmpdir = TempDir::new("pazi_integ").unwrap();
     let root = tmpdir.path();
     let mut h = HarnessBuilder::new(&root, &Pazi, shell).finish();
-    let igni = root.join("ignition").into_os_string().into_string().unwrap();
 
-    h.create_dir(&igni);
-    h.visit_dir(&igni);
-    h.visit_dir(&root.to_string_lossy());
-    assert_eq!(h.jump("igni"), igni);
+    // map of <DirectoryName, JumpTarget>
+    // Each will be tested that given a frecent directory of that name, a jump of the given target
+    // will end up there correctly.
+    let map: HashMap<_, _> = vec![
+        ("ignition", "igni"),
+        ("igni", "igni"),
+        ("initialize", "init"),
+        ("--help", "help"),
+        ("import", "import"),
+    ].into_iter().collect();
+
+    for (dir, jump) in map {
+        let dirname = root.join(dir).into_os_string().into_string().unwrap();
+        h.create_dir(&dirname);
+        h.visit_dir(&dirname);
+        h.visit_dir(&root.to_string_lossy());
+        assert_eq!(h.jump(jump), dirname);
+        h.delete_dir(&dirname);
+    }
 }

--- a/tests/src/integ.rs
+++ b/tests/src/integ.rs
@@ -168,7 +168,7 @@ fn it_prints_list_on_lonely_z_shell(shell: &Shell) {
     h.visit_dir(&root.join("2/tmp").to_string_lossy());
 
     let z_res = h.run_cmd("z");
-    let pazi_res = h.run_cmd("pazi");
+    let pazi_res = h.run_cmd("pazi view");
 
     assert_eq!(z_res, pazi_res);
     assert!(z_res.contains(&root.join("1/tmp").to_string_lossy().to_string()));


### PR DESCRIPTION
This fixes #70.

Prior to this change, there was a mix of subcommands and flags that were
all mutually-exclusive behaviours.
This ended up being a bit awkward and made some configurations
ambiguous.

This moves to a much nicer structure. There are global flags (right now
just debug), and then there are subcommands for each distinct
mode of operation.

For ease of migration, the previous logic still remains, but it can be
safely deleted after another release or so to allow migration.