### PR TITLE
Benchmark against jump

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "tests/testbins/z"]
 	path = tests/testbins/z
 	url = https://github.com/rupa/z
+[submodule "tests/testbins/jump"]
+	path = tests/testbins/jump
+	url = https://github.com/euank/jump

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,10 @@ env:
   global:
   - RUST_BACKTRACE=1
 
+before_script:
+- eval "$(gimme 1.11)" # golang for 'jump' benchmarks
+
 script:
 - cargo build --verbose --examples
 - cargo build --release # for integ tests
-- cd tests && cargo test -v --features="$([ "${TRAVIS_RUST_VERSION}" == "nightly" ] && echo nightly || echo default)" -- --test-threads=1
+- cd tests && make "$([ "${TRAVIS_RUST_VERSION}" == "nightly" ] && echo integ-all || echo integ)"

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -122,6 +122,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +248,7 @@ dependencies = [
  "chan 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "chan-signal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "directories 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -249,7 +259,6 @@ dependencies = [
  "tempfile 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -594,11 +603,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
-[[package]]
-name = "xdg"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
 [metadata]
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b3568b48b7cefa6b8ce125f9bb4989e52fbcc29ebea88df04cc7c5f12f70455"
@@ -616,6 +620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum chan-signal 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f1f1e11f6e1c14c9e805a87c622cb8fcb636283b3119a2150af390cc6702d7fe"
 "checksum clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)" = "110d43e343eb29f4f51c1db31beb879d546db27998577e5715270a54bcf41d3f"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum directories 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b106a38a9bf6c763c6c2e2c3332ab7635da453a68a6babca776386b3b287d338"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum errno 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1e2b2decb0484e15560df3210cf0d78654bb0864b2c138977c07e377a1bae0e2"
 "checksum failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7efb22686e4a466b1ec1a15c2898f91fa9cb340452496dca654032de20ff95b9"
@@ -675,4 +680,3 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a66b7c2281ebde13cf4391d70d4c7e5946c3c25e72a7b859ca8f677dcd0b0c61"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,8 +2,13 @@ CARGO_BIN:=$(shell which cargo)
 
 .PHONY: integ
 integ:
-	cd .. && cargo build --release
+	cd .. && $(CARGO_BIN) build --release
 	$(CARGO_BIN) test
+
+.PHONY: integ-all
+integ-all: jump
+	cd .. && $(CARGO_BIN) build --release
+	$(CARGO_BIN) test --features=nightly -- --test-threads=1
 
 .PHONY: bench
 bench: jump

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,18 @@
+CARGO_BIN:=$(shell which cargo)
+
+.PHONY: integ
+integ:
+	cd .. && cargo build --release
+	$(CARGO_BIN) test
+
+.PHONY: bench
+bench: jump
+	$(CARGO_BIN) bench --features=nightly
+
+.PHONY: bench-all
+bench-all: jump
+	sudo -E $(CARGO_BIN) bench --features=nightly,cgroups2
+
+.PHONY: jump
+jump:
+	make -C ./testbins/jump

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,24 @@
+# pazi tests and benchmarks
+
+This directorty contains integration tests and benchmarks for pazi.
+
+Since it contains benchmarks, it uses the `release` target of pazi found in the
+parent directory when running.
+
+It contains autojumpers that are benchmarked against as git submodules in the `testbins` subdirectory.
+
+## Running benchmarks
+
+Running pazi's benchmarks is somewhat involved, mostly because it's being benchmarked against several other pieces of software with varying requirements.
+
+It depends on your system's version of the following:
+
+* bash -- Used for all benchmarks, minimum required version unknown.
+* zsh -- Used for all benchmarks, minimum required version unknown.
+* go -- Used for `jump`, version >=1.11.
+* python -- Used for `autojump`, version 2.7 or 3.x.
+* cgroups -- Used for "sync" benchmarks for z and autojump, hybrid or unified cgroupsv2 must be mounted.
+* root -- Used for "sync" benchmarks.
+* rust -- Used for everything, nightly needed for benchmark support.
+
+Once you've got all that sorted out, running `make bench` or `make bench-all` should probably work.

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -52,10 +52,10 @@ fn main() {
                         r#"
     #[bench]{4}
     fn {0}(b: &mut Bencher) {{
-        {1}(b, &{2}, &Shell::{3});
+        {1}(b, &{2}, &Shell::{3}, {5});
     }}
     "#,
-                        &fn_name, &bench_name, &jumper, &shell, maybe_ignore,
+                        &fn_name, &bench_name, &jumper, &shell, maybe_ignore, bench_waits,
                     ).as_str();
                 }
             }

--- a/tests/src/bench.rs
+++ b/tests/src/bench.rs
@@ -1,15 +1,19 @@
 extern crate tempdir;
 extern crate test;
 
-use tempdir::TempDir;
-use harness::{Autojumper, Fasd, Jump, Z, HarnessBuilder, Harness, NoJumper, Pazi, Shell, Autojump};
 use self::test::Bencher;
+use harness::{
+    Autojump, Autojumper, Fasd, Harness, HarnessBuilder, Jump, NoJumper, Pazi, Shell, Z,
+};
 use std::path::Path;
+use tempdir::TempDir;
 
 fn cd_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell, sync: bool) {
     let tmpdir = TempDir::new("pazi_bench").unwrap();
     let root = tmpdir.path();
-    let mut h = HarnessBuilder::new(&root, jumper, shell).cgroup(sync).finish();
+    let mut h = HarnessBuilder::new(&root, jumper, shell)
+        .cgroup(sync)
+        .finish();
 
     // ensure we hit different directories on adjacent iterations; autojumpers may validly avoid
     // doing work on 'cd .'.
@@ -29,7 +33,9 @@ fn cd_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell, sync: bool) {
 fn jump_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell, sync: bool) {
     let tmpdir = TempDir::new("pazi_bench").unwrap();
     let root = tmpdir.into_path();
-    let mut h = HarnessBuilder::new(&root, jumper, shell).cgroup(sync).finish();
+    let mut h = HarnessBuilder::new(&root, jumper, shell)
+        .cgroup(sync)
+        .finish();
 
     // ensure we hit different directories on adjacent iterations; some autojumpers (cough `jump`)
     // refuse to jump to cwd
@@ -50,7 +56,9 @@ fn jump_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell, sync: bool) {
 fn jump_large_db_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell, sync: bool) {
     let tmpdir = TempDir::new("pazi_bench").unwrap();
     let root = tmpdir.path();
-    let mut h = HarnessBuilder::new(&root, jumper, shell).cgroup(sync).finish();
+    let mut h = HarnessBuilder::new(&root, jumper, shell)
+        .cgroup(sync)
+        .finish();
 
     create_and_visit_dirs(&mut h, &root, "dbnoise", 1000, sync);
 
@@ -73,7 +81,13 @@ struct JumpTarget {
     name: String,
 }
 
-fn create_and_visit_dirs(h: &mut Harness, root: &Path, prefix: &str, n: isize, sync: bool) -> Vec<JumpTarget> {
+fn create_and_visit_dirs(
+    h: &mut Harness,
+    root: &Path,
+    prefix: &str,
+    n: isize,
+    sync: bool,
+) -> Vec<JumpTarget> {
     let mut res = Vec::new();
     for i in 0..n {
         let name = format!("{}_{}", prefix, i);
@@ -83,7 +97,7 @@ fn create_and_visit_dirs(h: &mut Harness, root: &Path, prefix: &str, n: isize, s
         if sync {
             h.wait_children();
         }
-        res.push(JumpTarget{
+        res.push(JumpTarget {
             path: path,
             name: name,
         });

--- a/tests/src/bench.rs
+++ b/tests/src/bench.rs
@@ -5,33 +5,10 @@ use tempdir::TempDir;
 use harness::{Autojumper, Fasd, Z, HarnessBuilder, NoJumper, Pazi, Shell, Autojump};
 use self::test::Bencher;
 
-fn cd_bench_normal(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
+fn cd_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell, sync: bool) {
     let tmpdir = TempDir::new("pazi_bench").unwrap();
     let root = tmpdir.path();
     let mut h = HarnessBuilder::new(&root, jumper, shell).finish();
-    let dir1p = root.join("tmp1");
-    let dir2p = root.join("tmp2");
-    let dir1 = dir1p.to_str().unwrap();
-    let dir2 = dir2p.to_str().unwrap();
-
-    h.create_dir(&dir1);
-    h.create_dir(&dir2);
-
-    // ensure we hit different directories on adjacent iterations; autojumpers may validly avoid
-    // doing work on 'cd .'.
-    let mut iter = 0;
-
-    b.iter(move || {
-        let dir = if iter % 2 == 0 { &dir1 } else { &dir2 };
-        iter += 1;
-        h.visit_dir(dir)
-    });
-}
-
-fn cd_bench_sync(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
-    let tmpdir = TempDir::new("pazi_bench").unwrap();
-    let root = tmpdir.path();
-    let mut h = HarnessBuilder::new(&root, jumper, shell).cgroup(true).finish();
     let dir1p = root.join("tmp1");
     let dir2p = root.join("tmp2");
     let dir1 = dir1p.to_str().unwrap();
@@ -48,31 +25,34 @@ fn cd_bench_sync(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
         let dir = if iter % 2 == 0 { &dir1 } else { &dir2 };
         iter += 1;
         h.visit_dir(dir);
-        h.wait_children();
-        true
+        if sync {
+            h.wait_children()
+        }
     });
 }
 
-fn jump_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
+fn jump_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell, sync: bool) {
     let tmpdir = TempDir::new("pazi_bench").unwrap();
     let root = tmpdir.path();
-    let mut h = HarnessBuilder::new(&root, jumper, shell).cgroup(true).finish();
+    let mut h = HarnessBuilder::new(&root, jumper, shell).cgroup(sync).finish();
     let dir1p = root.join("tmp1");
     let dir1 = dir1p.to_str().unwrap();
 
     h.create_dir(&dir1);
     h.visit_dir(&dir1);
-    h.wait_children();
+    if sync {
+        h.wait_children();
+    }
 
     b.iter(move || {
         assert_eq!(&h.jump("tmp1"), dir1);
     });
 }
 
-fn jump_large_db_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
+fn jump_large_db_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell, sync: bool) {
     let tmpdir = TempDir::new("pazi_bench").unwrap();
     let root = tmpdir.path();
-    let mut h = HarnessBuilder::new(&root, jumper, shell).cgroup(true).finish();
+    let mut h = HarnessBuilder::new(&root, jumper, shell).cgroup(sync).finish();
     let dirp = root.join("tmp_target");
     let dir = dirp.to_str().unwrap();
 
@@ -81,35 +61,20 @@ fn jump_large_db_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
         let dirn = root.join(format!("tmp{}", i));
         h.create_dir(&dirn.to_string_lossy());
         h.visit_dir(&dirn.to_string_lossy());
-        h.wait_children();
+        if sync {
+            h.wait_children();
+        }
     }
 
     h.create_dir(&dir);
     h.visit_dir(&dir);
-    h.wait_children();
+    if sync {
+        h.wait_children();
+    }
 
     b.iter(move || {
         assert_eq!(&h.jump("tmp_target"), &dir);
     });
-}
-
-fn cd_50_bench(b: &mut Bencher, jumper: &Autojumper, shell: &Shell) {
-    let tmpdir = TempDir::new("pazi_bench").unwrap();
-    let root = tmpdir.path();
-    let mut h = HarnessBuilder::new(&root, jumper, shell).finish();
-    let dirs = (0..50)
-        .map(|num| format!("{}/dir{}", root.to_str().unwrap(), num))
-        .collect::<Vec<_>>();
-    for dir in &dirs {
-        h.create_dir(&dir);
-    }
-
-    let cmd = dirs.iter()
-        .map(|el| format!("cd '{}'", el))
-        .collect::<Vec<_>>()
-        .join(" && ");
-
-    b.iter(move || h.run_cmd(&cmd));
 }
 
 // This file is generated with 'build.rs' based on the contents of 'src/benches.csv'; to change the

--- a/tests/src/benches.csv
+++ b/tests/src/benches.csv
@@ -13,8 +13,9 @@
 # It works fine in bash, and the cd bench works, but for some reason the jump
 # one in zsh constantly hits that. I think it has to do with how $RANDOM works
 # in zsh.
-cd_bench_normal, NoJumper Pazi Fasd Autojump, Zsh Bash, false
-cd_bench_normal, Z, Bash, false
-cd_bench_sync, NoJumper Pazi Fasd Autojump Z, Zsh Bash, true
-jump_bench jump_large_db_bench, Pazi Fasd Autojump, Zsh Bash, true
+cd_bench, NoJumper Pazi Fasd, Zsh Bash, false
+cd_bench, Autojump, Zsh Bash, true
+cd_bench, Z, Bash, false
+jump_bench jump_large_db_bench, Pazi Fasd, Zsh Bash, false
+jump_bench jump_large_db_bench, Autojump, Zsh Bash, true
 jump_bench jump_large_db_bench, Z, Bash, true

--- a/tests/src/benches.csv
+++ b/tests/src/benches.csv
@@ -13,9 +13,9 @@
 # It works fine in bash, and the cd bench works, but for some reason the jump
 # one in zsh constantly hits that. I think it has to do with how $RANDOM works
 # in zsh.
-cd_bench, NoJumper Pazi Fasd, Zsh Bash, false
+cd_bench, NoJumper Pazi Fasd Jump, Zsh Bash, false
 cd_bench, Autojump, Zsh Bash, true
 cd_bench, Z, Bash, false
-jump_bench jump_large_db_bench, Pazi Fasd, Zsh Bash, false
+jump_bench jump_large_db_bench, Pazi Fasd Jump, Zsh Bash, false
 jump_bench jump_large_db_bench, Autojump, Zsh Bash, true
 jump_bench jump_large_db_bench, Z, Bash, true

--- a/tests/src/harness/autojumpers/autojump.rs
+++ b/tests/src/harness/autojumpers/autojump.rs
@@ -9,7 +9,8 @@ pub struct Autojump;
 impl Autojump {
     fn shell_path(&self, shell: &str) -> String {
         let crate_dir = env::var("CARGO_MANIFEST_DIR").expect("build with cargo");
-        let shell_path = Path::new(&crate_dir).join(format!("testbins/autojump/bin/autojump.{}", shell));
+        let shell_path =
+            Path::new(&crate_dir).join(format!("testbins/autojump/bin/autojump.{}", shell));
 
         if !shell_path.exists() {
             panic!("update submodules before running benches");
@@ -19,17 +20,15 @@ impl Autojump {
             .unwrap()
             .to_string_lossy()
             .to_string()
-
     }
 }
-
 
 impl Autojumper for Autojump {
     fn bin_path(&self) -> String {
         let crate_dir = env::var("CARGO_MANIFEST_DIR").expect("build with cargo");
         let bin_path = Path::new(&crate_dir).join(format!("testbins/autojump/bin/autojump"));
 
-        if !bin_path .exists() {
+        if !bin_path.exists() {
             panic!("update submodules before running benches");
         }
         bin_path
@@ -42,12 +41,12 @@ impl Autojumper for Autojump {
     fn init_for(&self, shell: &Shell) -> String {
         match shell {
             &Shell::Bash => format!("source '{}'", self.shell_path("bash")),
-            &Shell::Zsh=> format!("source '{}'", self.shell_path("zsh")),
+            &Shell::Zsh => format!("source '{}'", self.shell_path("zsh")),
             &Shell::Conch => unimplemented!(),
         }
     }
 
-    fn jump_alias(&self) -> &'static str{
+    fn jump_alias(&self) -> &'static str {
         "j"
     }
 }

--- a/tests/src/harness/autojumpers/fasd.rs
+++ b/tests/src/harness/autojumpers/fasd.rs
@@ -41,7 +41,7 @@ eval "$({} --init posix-alias bash-hook)"
         }
     }
 
-    fn jump_alias(&self) -> &'static str{
+    fn jump_alias(&self) -> &'static str {
         "z"
     }
 }

--- a/tests/src/harness/autojumpers/jump.rs
+++ b/tests/src/harness/autojumpers/jump.rs
@@ -1,0 +1,39 @@
+use super::Autojumper;
+use harness::Shell;
+use std::env;
+use std::path::Path;
+
+pub struct Jump;
+
+impl Autojumper for Jump {
+    fn bin_path(&self) -> String {
+        let crate_dir = env::var("CARGO_MANIFEST_DIR").expect("build with cargo");
+        let bin_path = Path::new(&crate_dir).join(format!("testbins/jump/jump"));
+
+        if !bin_path.exists() {
+            panic!("update submodules before running benches");
+        }
+        bin_path
+            .canonicalize()
+            .unwrap()
+            .to_string_lossy()
+            .to_string()
+    }
+
+    fn init_for(&self, shell: &Shell) -> String {
+        match shell {
+            &Shell::Bash | &Shell::Zsh => format!(
+                r#"
+eval "$({} shell {})"
+"#,
+                self.bin_path(),
+                shell.name(),
+            ),
+            &Shell::Conch => unimplemented!(),
+        }
+    }
+
+    fn jump_alias(&self) -> &'static str{
+        "j"
+    }
+}

--- a/tests/src/harness/autojumpers/jump.rs
+++ b/tests/src/harness/autojumpers/jump.rs
@@ -33,7 +33,7 @@ eval "$({} shell {})"
         }
     }
 
-    fn jump_alias(&self) -> &'static str{
+    fn jump_alias(&self) -> &'static str {
         "j"
     }
 }

--- a/tests/src/harness/autojumpers/mod.rs
+++ b/tests/src/harness/autojumpers/mod.rs
@@ -1,8 +1,8 @@
-pub mod pazi;
-pub mod fasd;
 pub mod autojump;
-pub mod z;
+pub mod fasd;
 pub mod jump;
+pub mod pazi;
+pub mod z;
 
 use harness::Shell;
 
@@ -23,7 +23,7 @@ impl Autojumper for None {
     fn init_for(&self, _: &Shell) -> String {
         "".to_owned()
     }
-    fn jump_alias(&self) -> &'static str{
+    fn jump_alias(&self) -> &'static str {
         panic!("'None' can't jump");
     }
 }

--- a/tests/src/harness/autojumpers/mod.rs
+++ b/tests/src/harness/autojumpers/mod.rs
@@ -2,6 +2,7 @@ pub mod pazi;
 pub mod fasd;
 pub mod autojump;
 pub mod z;
+pub mod jump;
 
 use harness::Shell;
 

--- a/tests/src/harness/autojumpers/z.rs
+++ b/tests/src/harness/autojumpers/z.rs
@@ -32,7 +32,7 @@ impl Autojumper for Z {
         }
     }
 
-    fn jump_alias(&self) -> &'static str{
+    fn jump_alias(&self) -> &'static str {
         "z"
     }
 }

--- a/tests/src/harness/mod.rs
+++ b/tests/src/harness/mod.rs
@@ -11,6 +11,7 @@ pub use self::autojumpers::Autojumper;
 pub use self::autojumpers::pazi::Pazi;
 pub use self::autojumpers::fasd::Fasd;
 pub use self::autojumpers::z::Z;
+pub use self::autojumpers::jump::Jump;
 pub use self::autojumpers::autojump::Autojump;
 pub use self::autojumpers::None as NoJumper;
 

--- a/tests/src/harness/mod.rs
+++ b/tests/src/harness/mod.rs
@@ -1,19 +1,19 @@
-mod testshell;
-mod shells;
 mod autojumpers;
+mod shells;
+mod testshell;
 
-use std::path::Path;
 use self::testshell::TestShell;
 use std::fs;
+use std::path::Path;
 
-pub use self::shells::Shell;
-pub use self::autojumpers::Autojumper;
-pub use self::autojumpers::pazi::Pazi;
-pub use self::autojumpers::fasd::Fasd;
-pub use self::autojumpers::z::Z;
-pub use self::autojumpers::jump::Jump;
 pub use self::autojumpers::autojump::Autojump;
+pub use self::autojumpers::fasd::Fasd;
+pub use self::autojumpers::jump::Jump;
+pub use self::autojumpers::pazi::Pazi;
+pub use self::autojumpers::z::Z;
+pub use self::autojumpers::Autojumper;
 pub use self::autojumpers::None as NoJumper;
+pub use self::shells::Shell;
 
 pub struct Harness<'a> {
     testshell: TestShell,
@@ -50,12 +50,24 @@ impl<'a> HarnessBuilder<'a> {
     }
 
     pub fn finish(self) -> Harness<'a> {
-        Harness::new(self.root, self.shell, self.jumper, self.preinit, self.cgroup)
+        Harness::new(
+            self.root,
+            self.shell,
+            self.jumper,
+            self.preinit,
+            self.cgroup,
+        )
     }
 }
 
 impl<'a> Harness<'a> {
-    fn new(root: &Path, shell: &Shell, jumper: &'a Autojumper, preinit: Option<&str>, cgroup: bool) -> Self {
+    fn new(
+        root: &Path,
+        shell: &Shell,
+        jumper: &'a Autojumper,
+        preinit: Option<&str>,
+        cgroup: bool,
+    ) -> Self {
         let ps1 = "==PAZI==> ";
         shell.setup(&root, jumper, ps1, preinit.unwrap_or(""));
 
@@ -84,7 +96,11 @@ impl<'a> Harness<'a> {
     }
 
     pub fn jump(&mut self, search: &str) -> String {
-        self.testshell.run(&format!("{} '{}' >/dev/null && pwd", self.jumper.jump_alias(), search))
+        self.testshell.run(&format!(
+            "{} '{}' >/dev/null && pwd",
+            self.jumper.jump_alias(),
+            search
+        ))
     }
 
     pub fn run_cmd(&mut self, cmd: &str) -> String {

--- a/tests/src/harness/shells.rs
+++ b/tests/src/harness/shells.rs
@@ -1,12 +1,13 @@
-use std::path::Path;
 use harness::autojumpers::Autojumper;
 use std::fs;
 use std::io::Write;
+use std::path::Path;
 
 pub enum Shell {
     Bash,
     Zsh,
-    #[allow(dead_code)] Conch,
+    #[allow(dead_code)]
+    Conch,
 }
 
 pub struct ShellCmd<'a> {

--- a/tests/src/harness/testshell/mod.rs
+++ b/tests/src/harness/testshell/mod.rs
@@ -1,17 +1,17 @@
-extern crate pty;
-extern crate vte;
 extern crate libc;
+extern crate pty;
 extern crate rand;
+extern crate vte;
 
-use std::os::unix::process::CommandExt;
-use std::process::Command;
-use std::path::Path;
 use std::fs;
 use std::io::Read;
 use std::io::Write;
-use std::time::Duration;
+use std::os::unix::process::CommandExt;
+use std::path::Path;
+use std::process::Command;
 use std::sync::mpsc;
 use std::thread;
+use std::time::Duration;
 
 use self::rand::Rng;
 
@@ -19,7 +19,8 @@ use super::shells;
 
 pub struct TestShell {
     // fork is here for lifetime reasons; can't drop it until the pty is done
-    #[allow(unused)] fork: pty::fork::Fork,
+    #[allow(unused)]
+    fork: pty::fork::Fork,
     pty: pty::fork::Master,
     pid: libc::pid_t,
     output: mpsc::Receiver<String>,
@@ -167,8 +168,12 @@ impl TestShell {
         };
 
         if let Some(cg) = cgpath.clone() {
-            let mut f = fs::OpenOptions::new().write(true).open(format!("{}/cgroup.procs", cg)).expect("no cgroup.procs file");
-            f.write(format!("{}\n", child_pid).as_bytes()).expect("write pid err");
+            let mut f = fs::OpenOptions::new()
+                .write(true)
+                .open(format!("{}/cgroup.procs", cg))
+                .expect("no cgroup.procs file");
+            f.write(format!("{}\n", child_pid).as_bytes())
+                .expect("write pid err");
         }
 
         let (write_command_out, command_out) = mpsc::channel();
@@ -273,12 +278,12 @@ impl TestShell {
             for line in output.lines() {
                 let pid = line.parse::<i32>().unwrap();
                 if pid == self.pid {
-                    continue
+                    continue;
                 }
                 pids.push(pid);
             }
             if pids.len() == 0 {
-                return
+                return;
             }
             unsafe {
                 let mut status = 0;
@@ -295,8 +300,8 @@ impl TestShell {
 
 #[cfg(features = "testshell-dev")]
 mod dev {
-    use std::process::Command;
     use super::TestShell;
+    use std::process::Command;
     #[test]
     fn testshell() {
         let mut cmd = Command::new("zsh");

--- a/tests/src/integ.rs
+++ b/tests/src/integ.rs
@@ -1,12 +1,12 @@
 extern crate pazi;
 extern crate tempdir;
 
-use integ::pazi::shells::SUPPORTED_SHELLS;
-use tempdir::TempDir;
 use harness::{Fasd, HarnessBuilder, Pazi, Shell};
+use integ::pazi::shells::SUPPORTED_SHELLS;
 use std::collections::HashMap;
-use std::time::Duration;
 use std::thread::sleep;
+use std::time::Duration;
+use tempdir::TempDir;
 
 #[test]
 fn it_jumps() {
@@ -182,7 +182,9 @@ fn it_handles_existing_bash_prompt_command() {
     let prompt_cmd = r#"
 PROMPT_COMMAND='printf "\033k%s@%s:%s\033\\" "${USER}" "${HOSTNAME%%.*}" "${PWD/#$HOME/\~}"'
 "#;
-    let mut h = HarnessBuilder::new(&root, &Pazi, &Shell::Bash).preinit(prompt_cmd).finish();
+    let mut h = HarnessBuilder::new(&root, &Pazi, &Shell::Bash)
+        .preinit(prompt_cmd)
+        .finish();
     let slash_tmp_path = root.join("tmp");
     let slash_tmp = slash_tmp_path.to_string_lossy();
 
@@ -239,7 +241,8 @@ fn it_handles_things_that_look_like_subcommands_shell(shell: &Shell) {
         ("initialize", "init"),
         ("--help", "help"),
         ("import", "import"),
-    ].into_iter().collect();
+    ].into_iter()
+    .collect();
 
     for (dir, jump) in map {
         let dirname = root.join(dir).into_os_string().into_string().unwrap();


### PR DESCRIPTION
Closes #82.

Preliminary results:

```
test bench::cd_bench_autojump_bash            ... bench:  61,206,943 ns/iter (+/- 3,793,731)
test bench::cd_bench_autojump_zsh             ... bench:  62,042,056 ns/iter (+/- 4,531,715)
test bench::cd_bench_fasd_bash                ... bench:  22,266,885 ns/iter (+/- 3,308,704)
test bench::cd_bench_fasd_zsh                 ... bench:  19,945,300 ns/iter (+/- 2,400,944)
test bench::cd_bench_jump_bash                ... bench:   2,739,991 ns/iter (+/- 610,425)
test bench::cd_bench_jump_zsh                 ... bench:   2,600,361 ns/iter (+/- 564,764)
test bench::cd_bench_nojumper_bash            ... bench:     188,041 ns/iter (+/- 54,984)
test bench::cd_bench_nojumper_zsh             ... bench:      37,384 ns/iter (+/- 11,962)
test bench::cd_bench_pazi_bash                ... bench:   1,821,075 ns/iter (+/- 395,191)
test bench::cd_bench_pazi_zsh                 ... bench:   1,608,968 ns/iter (+/- 570,797)
test bench::cd_bench_z_bash                   ... bench:   1,702,148 ns/iter (+/- 739,164)
test bench::jump_bench_autojump_bash          ... bench:  62,575,631 ns/iter (+/- 1,899,814)
test bench::jump_bench_autojump_zsh           ... bench:  63,028,706 ns/iter (+/- 4,206,985)
test bench::jump_bench_fasd_bash              ... bench:  47,023,727 ns/iter (+/- 5,376,159)
test bench::jump_bench_fasd_zsh               ... bench:  44,355,551 ns/iter (+/- 4,117,366)
test bench::jump_bench_jump_bash              ... bench:   5,618,875 ns/iter (+/- 1,461,983)
test bench::jump_bench_jump_zsh               ... bench:   5,455,400 ns/iter (+/- 1,185,344)
test bench::jump_bench_pazi_bash              ... bench:   4,021,471 ns/iter (+/- 987,933)
test bench::jump_bench_pazi_zsh               ... bench:   3,900,815 ns/iter (+/- 951,695)
test bench::jump_bench_z_bash                 ... bench:   5,293,434 ns/iter (+/- 1,112,035)
test bench::jump_large_db_bench_autojump_bash ... bench:  72,744,779 ns/iter (+/- 5,698,795)
test bench::jump_large_db_bench_autojump_zsh  ... bench:  71,554,195 ns/iter (+/- 3,850,932)
test bench::jump_large_db_bench_fasd_bash     ... bench:  51,442,389 ns/iter (+/- 4,759,051)
test bench::jump_large_db_bench_fasd_zsh      ... bench:  49,430,736 ns/iter (+/- 5,815,019)
test bench::jump_large_db_bench_jump_bash     ... bench:  28,186,669 ns/iter (+/- 1,910,657)
test bench::jump_large_db_bench_jump_zsh      ... bench:  28,160,278 ns/iter (+/- 2,380,014)
test bench::jump_large_db_bench_pazi_bash     ... bench:  24,001,807 ns/iter (+/- 1,488,314)
test bench::jump_large_db_bench_pazi_zsh      ... bench:  23,926,722 ns/iter (+/- 1,291,600)
test bench::jump_large_db_bench_z_bash        ... bench:  23,319,705 ns/iter (+/- 5,810,052)
```