### PR TITLE
Fix error setting PROMPT_COMMAND in bash

### DIFF
--- a/src/shells/bash.rs
+++ b/src/shells/bash.rs
@@ -15,9 +15,9 @@ __pazi_add_dir() {
     __PAZI_LAST_PWD="${PWD}"
 }
 
-case \$PROMPT_COMMAND in
-    *__pazi_add_dir\;*) ;;
-    *) PROMPT_COMMAND="__pazi_add_dir;\$PROMPT_COMMMAND" ;;
+case "${PROMPT_COMMAND}" in
+    *__pazi_add_dir;*) ;;
+    *) PROMPT_COMMAND="__pazi_add_dir;${PROMPT_COMMMAND}" ;;
 esac
 
 pazi_cd() {


### PR DESCRIPTION
The PROMPT_COMMAND environmental variable is setup incorrectly by `pazi`:
```shell
$ unset PROMPT_COMMAND
$ eval "$(pazi init bash)"
$ echo $PROMPT_COMMAND
__pazi_add_dir;$PROMPT_COMMMAND   # should be __pazi_add_dir;
$ PROMPT_COMMAND="__pazi_add_dir;" eval "$(pazi init bash)"
$ echo $PROMPT_COMMAND
__pazi_add_dir;$PROMPT_COMMMAND  # should be __pazi_add_dir;
```