### PR TITLE
tests: explicitly pass through PATH

### DIFF
--- a/tests/src/harness/testshell/mod.rs
+++ b/tests/src/harness/testshell/mod.rs
@@ -148,6 +148,7 @@ impl TestShell {
         let mut shellcmd = Command::new(cmd.cmd);
         shellcmd.env_clear();
         shellcmd.env("PS1", ps1);
+        shellcmd.env("PATH", std::env::var("PATH").unwrap());
         for env in cmd.env {
             shellcmd.env(env.0, env.1);
         }


### PR DESCRIPTION
This avoids a regression in nightly (reported
https://github.com/rust-lang/rust/issues/55775).

It makes sense to pass through the path after 'env_clear' anyway though
given shells are just run by bin name, not full bin path.