### PR TITLE
Added shell completion for zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ if command -v pazi &>/dev/null; then
 fi
 ```
 
+Note: The init should be added after `autoload -Uz compinit; compinit;`
+has been called since `pazi init zsh` initializes completion for the `z` command.
+
 Or if you are a fish user, add the following to your `config.fish`
 
 ```sh

--- a/src/main.rs
+++ b/src/main.rs
@@ -557,6 +557,14 @@ fn intercept_ctrl_c() -> Result<(), ()> {
     }
 
     unsafe {
+        // If STDIN isn't a tty, we can't reasonably make ourselves
+        // the foreground process group, so just give up
+        // (happens during zsh autocompletion)
+        let isatty_res = libc::isatty(libc::STDIN_FILENO);
+        if isatty_res == 0 {
+            return Ok(());
+        }
+
         // Create a new process group with this process in it.
         let setpgid_res = libc::setpgid(0, 0);
         let errno = *get_errno();

--- a/src/shells/zsh.rs
+++ b/src/shells/zsh.rs
@@ -44,8 +44,11 @@ _pazi_cd() {
   _describe -V -t pazi-dirs 'pazi' suggestions
 }
 
-compdef _pazi_cd pazi_cd 'pazi jump'
-zstyle ':completion::complete:pazi_cd:*:pazi-dirs' matcher 'l:|=* r:|=*'
+if whence compdef>/dev/null; then
+  compdef _pazi_cd pazi_cd 'pazi jump'
+  zstyle ':completion::complete:pazi_cd:*:pazi-dirs' matcher 'l:|=* r:|=*'
+fi
+
 "#,
         )
     }

--- a/src/shells/zsh.rs
+++ b/src/shells/zsh.rs
@@ -37,6 +37,14 @@ pazi_cd() {
     esac
 }
 alias z='pazi_cd'
+"#,
+            r#"_pazi_cd() {
+  CURRENTWORD="${LBUFFER/* /}${RBUFFER/ */}"
+  local subcmds=(${(f)"$(pazi complete $CURRENTWORD)"})
+  _describe 'pazi' subcmds
+}
+
+compdef _pazi_cd pazi_cd 'pazi jump'
 "#
         )
     }

--- a/src/shells/zsh.rs
+++ b/src/shells/zsh.rs
@@ -41,7 +41,7 @@ alias z='pazi_cd'
 _pazi_cd() {
   CURRENTWORD="${LBUFFER/* /}${RBUFFER/ */}"
   local suggestions=(${(f)"$(pazi complete zsh $CURRENTWORD)"})
-  _describe -t pazi-dirs 'pazi' suggestions
+  _describe -V -t pazi-dirs 'pazi' suggestions
 }
 
 compdef _pazi_cd pazi_cd 'pazi jump'

--- a/src/shells/zsh.rs
+++ b/src/shells/zsh.rs
@@ -37,16 +37,16 @@ pazi_cd() {
     esac
 }
 alias z='pazi_cd'
-"#,
-            r#"_pazi_cd() {
+
+_pazi_cd() {
   CURRENTWORD="${LBUFFER/* /}${RBUFFER/ */}"
-  local suggestions=(${(f)"$(pazi complete $CURRENTWORD)"})
+  local suggestions=(${(f)"$(pazi complete zsh $CURRENTWORD)"})
   _describe -t pazi-dirs 'pazi' suggestions
 }
 
 compdef _pazi_cd pazi_cd 'pazi jump'
 zstyle ':completion::complete:pazi_cd:*:pazi-dirs' matcher 'l:|=* r:|=*'
-"#
+"#,
         )
     }
 }

--- a/src/shells/zsh.rs
+++ b/src/shells/zsh.rs
@@ -40,8 +40,8 @@ alias z='pazi_cd'
 "#,
             r#"_pazi_cd() {
   CURRENTWORD="${LBUFFER/* /}${RBUFFER/ */}"
-  local subcmds=(${(f)"$(pazi complete $CURRENTWORD)"})
-  _describe -t pazi-dirs 'pazi' subcmds
+  local suggestions=(${(f)"$(pazi complete $CURRENTWORD)"})
+  _describe -t pazi-dirs 'pazi' suggestions
 }
 
 compdef _pazi_cd pazi_cd 'pazi jump'

--- a/src/shells/zsh.rs
+++ b/src/shells/zsh.rs
@@ -40,7 +40,7 @@ alias z='pazi_cd'
 
 _pazi_cd() {
   CURRENTWORD="${LBUFFER/* /}${RBUFFER/ */}"
-  local suggestions=(${(f)"$(pazi complete zsh $CURRENTWORD)"})
+  local suggestions=(${(f)"$(pazi complete zsh -- $CURRENTWORD)"})
   _describe -V -t pazi-dirs 'pazi' suggestions
 }
 

--- a/src/shells/zsh.rs
+++ b/src/shells/zsh.rs
@@ -41,10 +41,11 @@ alias z='pazi_cd'
             r#"_pazi_cd() {
   CURRENTWORD="${LBUFFER/* /}${RBUFFER/ */}"
   local subcmds=(${(f)"$(pazi complete $CURRENTWORD)"})
-  _describe 'pazi' subcmds
+  _describe -t pazi-dirs 'pazi' subcmds
 }
 
 compdef _pazi_cd pazi_cd 'pazi jump'
+zstyle ':completion::complete:pazi_cd:*:pazi-dirs' matcher 'l:|=* r:|=*'
 "#
         )
     }

--- a/tests/src/harness/autojumpers/pazi.rs
+++ b/tests/src/harness/autojumpers/pazi.rs
@@ -20,9 +20,8 @@ impl Autojumper for Pazi {
 
     fn init_for(&self, shell: &Shell) -> String {
         match shell {
-            &Shell::Bash | &Shell::Zsh => {
-                format!(r#"set -u; eval "$(pazi init {})""#, shell.name())
-            }
+            &Shell::Bash => format!(r#"set -u; eval "$(pazi init {})""#, shell.name()),
+            &Shell::Zsh => format!(r#"set -u; autoload -Uz compinit; compinit; eval "$(pazi init {})""#, shell.name()),
             &Shell::Fish => "status --is-interactive; and pazi init fish | source".to_string(),
         }
     }


### PR DESCRIPTION
Added zsh shell completion
Addresses https://github.com/euank/pazi/issues/10

Here is what it looks like:
[![asciicast](https://asciinema.org/a/225721.svg)](https://asciinema.org/a/225721)

I am not sure whether this is how you envisioned the shell completion. This could be more of a minimum viable implementation of the idea. 

- One possibly better way to implement the completion instead of outputting the whole paths would be to output the part of the path that matches the input along with the path as the description.

- Another improvement I could see would be to have the complete subcommand have further subcommands for each supported shell, each outputting in a different way as needed by the shell?
  - Or the other way around, output in a specific format and do the heavy lifting in the completion function of the shell