### PR TITLE
tests: Always build pazi for makefile targets

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,28 +1,29 @@
 CARGO_BIN:=$(shell which cargo)
 
 .PHONY: integ
-integ:
-	cd .. && $(CARGO_BIN) build --release
+integ: pazi
 	$(CARGO_BIN) test -- --test-threads=1
 
-integ-nightly: jump
-	cd .. && $(CARGO_BIN) build --release
+integ-nightly: pazi jump
 	$(CARGO_BIN) test --features=nightly -- --test-threads=1
 
 .PHONY: integ-all
-integ-all: jump
-	cd .. && $(CARGO_BIN) build --release
+integ-all: pazi jump
 	test_bin=$$($(CARGO_BIN) test --no-run --features=nightly,cgroups2 --message-format=json | jq -r "select(.profile.test == true) | .filenames[]") ;\
 		sudo CARGO_MANIFEST_DIR=$$PWD $$test_bin --test-threads=1
 
 .PHONY: bench
-bench: jump
+bench: pazi jump
 	$(CARGO_BIN) bench --features=nightly
 
 .PHONY: bench-all
-bench-all: jump
+bench-all: pazi jump
 	sudo -E $(CARGO_BIN) bench --features=nightly,cgroups2
 
 .PHONY: jump
 jump:
 	make -C ./testbins/jump
+
+.PHONY: pazi
+pazi:
+	cd .. && $(CARGO_BIN) build --release


### PR DESCRIPTION
Prevents accidental stale pazi builds when doing benches.
This may or may not be driven by real-life confusion.