### PR TITLE
Use forks in __pazi_add_dir

### DIFF
--- a/src/shells/bash.rs
+++ b/src/shells/bash.rs
@@ -10,7 +10,7 @@ impl Shell for Bash {
 __pazi_add_dir() {
     # TODO: should pazi keep track of this itself in its datadir?
     if [[ "${__PAZI_LAST_PWD:-}" != "${PWD}" ]]; then
-        pazi visit "${PWD}"
+        { pazi visit "${PWD}" & } 2>/dev/null; disown
     fi
     __PAZI_LAST_PWD="${PWD}"
 }

--- a/src/shells/fish.rs
+++ b/src/shells/fish.rs
@@ -36,7 +36,7 @@ end
 
 function __pazi_preexec --on-variable PWD
     status --is-command-substitution; and return
-    pazi visit (pwd)
+    pazi visit (pwd) &; disown
 end
 
 alias z 'pazi_cd'

--- a/src/shells/zsh.rs
+++ b/src/shells/zsh.rs
@@ -7,7 +7,7 @@ impl Shell for Zsh {
         concat!(
             r#"
 __pazi_add_dir() {
-    pazi visit "${PWD}"
+    pazi visit "${PWD}" &!
 }
 
 autoload -Uz add-zsh-hook


### PR DESCRIPTION
Pazi currently does not seem to use forks in its `precmd/preexec/chpwd` functions. This, however fast pazi might be, should result in a loss of performance.

This PR adds forking to the `__pazi_add_dir` functions for all shells. Subshells are explicitly avoided as they are not very performant.