### PR TITLE
ci: switch from travis-ci to drone-ci

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,9 @@
+kind: pipeline
+type: docker
+name: test
+
+steps:
+- name: test
+  image: rust:1.48-buster
+  commands:
+  - cargo test


### PR DESCRIPTION
travis-ci has added some quite severe limits on builders etc.

It's time to move on to something else. drone-ci seems like a pretty reasonable option, so for now I think we'll try going with that.

This PR will be to try and get everything ported over to it in a reasonable way.