### PR TITLE
tests: add zoxide to benchmarks

### DIFF
--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -25,6 +25,7 @@
         export AUTOJUMP_HOOKS=${pkgs.autojump}/share/autojump/
         export FASD_BIN=${pkgs.fasd}/bin/fasd
         export RUPA_Z_BIN=${pkgs.rupa_z}/share/z.sh
+        export ZOXIDE_BIN=${pkgs.zoxide}/bin/zoxide
 
         CARGO_BIN=$(which cargo)
         export PATH="${pkgs.zsh}/bin:${pkgs.coreutils}/bin:${pkgs.bashInteractive}/bin:${pkgs.fish}/bin:$PATH"

--- a/tests/src/bench.rs
+++ b/tests/src/bench.rs
@@ -2,7 +2,7 @@ extern crate test;
 
 use test::Bencher;
 use crate::harness::{
-    Autojump, Autojumper, Fasd, Harness, HarnessBuilder, Jump, NoJumper, Pazi, Shell, Z,
+    Autojump, Autojumper, Fasd, Harness, HarnessBuilder, Jump, NoJumper, Pazi, Shell, Z, Zoxide,
 };
 use std::path::Path;
 use tempdir::TempDir;

--- a/tests/src/benches.csv
+++ b/tests/src/benches.csv
@@ -4,7 +4,7 @@
 # 1. The name of the benchmark function to run
 # 2. A space-separated list of "Autojumper"s, 'j'
 # 3. A space-separated list of shells, 's'
-# 
+#
 # The generated benchmarks will test all combinations j * s for that function.
 #
 # Note: z is left out of benches with zsh because it frequently fails and prints:
@@ -12,9 +12,9 @@
 # It works fine in bash, and the cd bench works, but for some reason the jump
 # one in zsh constantly hits that. I think it has to do with how $RANDOM works
 # in zsh.
-cd_bench, NoJumper Pazi Fasd Jump, Zsh Bash
+cd_bench, NoJumper Pazi Fasd Jump Zoxide, Zsh Bash
 cd_bench, Autojump, Zsh Bash
 cd_bench, Z, Bash
-jump_bench jump_large_db_bench, Pazi Fasd Jump, Zsh Bash
+jump_bench jump_large_db_bench, Pazi Fasd Jump Zoxide, Zsh Bash
 jump_bench jump_large_db_bench, Autojump, Zsh Bash
 jump_bench jump_large_db_bench, Z, Bash

--- a/tests/src/harness/autojumpers/mod.rs
+++ b/tests/src/harness/autojumpers/mod.rs
@@ -1,6 +1,7 @@
 pub mod autojump;
 pub mod fasd;
 pub mod jump;
+pub mod zoxide;
 pub mod pazi;
 pub mod z;
 

--- a/tests/src/harness/autojumpers/zoxide.rs
+++ b/tests/src/harness/autojumpers/zoxide.rs
@@ -1,0 +1,45 @@
+use super::Autojumper;
+use crate::harness::Shell;
+use std::env;
+use std::path::{PathBuf, Path};
+
+pub struct Zoxide;
+
+impl Autojumper for Zoxide {
+    fn bin_path(&self) -> PathBuf {
+        let bin = env::var("ZOXIDE_BIN").expect("ZOXIDE_BIN environment variable should be set");
+        let bin_path = Path::new(&bin);
+
+        if !bin_path.exists() {
+            panic!("run tests with the makefile");
+        }
+        bin_path
+            .canonicalize()
+            .unwrap()
+    }
+
+    fn init_for(&self, shell: &Shell) -> String {
+        match shell {
+            &Shell::Bash | &Shell::Zsh => format!(
+                r#"
+eval "$({} init {})"
+"#,
+                self.bin_path().to_string_lossy(),
+                shell.name(),
+            ),
+            &Shell::Fish => format!("{} init fish | source", self.bin_path().to_string_lossy()),
+        }
+    }
+
+    fn supported_shells(&self) -> Vec<Shell> {
+        vec![Shell::Bash, Shell::Zsh]
+    }
+
+    fn jump_alias(&self) -> &'static str {
+        "z"
+    }
+
+    fn to_str(&self) -> &'static str {
+        "zoxide"
+    }
+}

--- a/tests/src/harness/mod.rs
+++ b/tests/src/harness/mod.rs
@@ -10,6 +10,7 @@ pub use self::autojumpers::autojump::Autojump;
 pub use self::autojumpers::fasd::Fasd;
 pub use self::autojumpers::jump::Jump;
 pub use self::autojumpers::pazi::Pazi;
+pub use self::autojumpers::zoxide::Zoxide;
 pub use self::autojumpers::z::Z;
 pub use self::autojumpers::Autojumper;
 pub use self::autojumpers::None as NoJumper;


### PR DESCRIPTION
This lets us version them the same way we do zsh and bash. It does add another dependency to runs tests and benches, but it actually removes the go dependency, so it's neutral I guess?

It also lets us lean on the nixpkgs's ecosystem for pulling in other benchmark targets without having to figure out how to build each one ourselves or such.

Preliminary benchmark results for zoxide vs everything (I'll update the real benchmark doc separately. I was running other stuff on  my computer with these benches, so it's less controlled than the benchmark doc's ones are):

```
test bench::cd_bench_autojump_bash            ... bench:  46,916,012 ns/iter (+/- 3,486,373)
test bench::cd_bench_autojump_zsh             ... bench:  45,835,440 ns/iter (+/- 2,711,631)
test bench::cd_bench_fasd_bash                ... bench:  11,791,500 ns/iter (+/- 695,110)
test bench::cd_bench_fasd_zsh                 ... bench:  10,820,399 ns/iter (+/- 261,236)
test bench::cd_bench_jump_bash                ... bench:   1,450,716 ns/iter (+/- 104,070)
test bench::cd_bench_jump_zsh                 ... bench:   1,474,706 ns/iter (+/- 71,239)
test bench::cd_bench_nojumper_bash            ... bench:      81,983 ns/iter (+/- 2,501)
test bench::cd_bench_nojumper_zsh             ... bench:      27,851 ns/iter (+/- 8,284)
test bench::cd_bench_pazi_bash                ... bench:     876,149 ns/iter (+/- 35,549)
test bench::cd_bench_pazi_zsh                 ... bench:     908,272 ns/iter (+/- 39,427)
test bench::cd_bench_z_bash                   ... bench:   3,233,277 ns/iter (+/- 164,996)
test bench::cd_bench_zoxide_bash              ... bench:   1,165,558 ns/iter (+/- 74,592)
test bench::cd_bench_zoxide_zsh               ... bench:     972,435 ns/iter (+/- 21,877)
test bench::jump_bench_autojump_bash          ... bench:  90,817,966 ns/iter (+/- 5,076,537)
test bench::jump_bench_autojump_zsh           ... bench:  90,395,896 ns/iter (+/- 3,572,639)
test bench::jump_bench_fasd_bash              ... bench:  26,246,808 ns/iter (+/- 679,379)
test bench::jump_bench_fasd_zsh               ... bench:  25,191,652 ns/iter (+/- 634,076)
test bench::jump_bench_jump_bash              ... bench:   3,080,467 ns/iter (+/- 98,263)
test bench::jump_bench_jump_zsh               ... bench:   3,097,708 ns/iter (+/- 81,116)
test bench::jump_bench_pazi_bash              ... bench:   1,741,090 ns/iter (+/- 81,712)
test bench::jump_bench_pazi_zsh               ... bench:   1,662,894 ns/iter (+/- 79,342)
test bench::jump_bench_z_bash                 ... bench:   5,505,143 ns/iter (+/- 121,712)
test bench::jump_bench_zoxide_bash            ... bench:   2,423,384 ns/iter (+/- 91,376)
test bench::jump_bench_zoxide_zsh             ... bench:   1,940,917 ns/iter (+/- 63,340)
test bench::jump_large_db_bench_autojump_bash ... bench: 108,354,048 ns/iter (+/- 3,642,736)
test bench::jump_large_db_bench_autojump_zsh  ... bench: 107,770,318 ns/iter (+/- 3,239,504)
test bench::jump_large_db_bench_fasd_bash     ... bench:  29,551,209 ns/iter (+/- 3,252,797)
test bench::jump_large_db_bench_fasd_zsh      ... bench:  29,035,209 ns/iter (+/- 1,280,172)
test bench::jump_large_db_bench_jump_bash     ... bench:  21,049,952 ns/iter (+/- 799,966)
test bench::jump_large_db_bench_jump_zsh      ... bench:  21,048,251 ns/iter (+/- 963,205)
test bench::jump_large_db_bench_pazi_bash     ... bench:  11,093,209 ns/iter (+/- 417,444)
test bench::jump_large_db_bench_pazi_zsh      ... bench:  10,996,971 ns/iter (+/- 829,344)
test bench::jump_large_db_bench_z_bash        ... bench:  27,964,954 ns/iter (+/- 990,254)
test bench::jump_large_db_bench_zoxide_bash   ... bench:   2,623,565 ns/iter (+/- 118,757)
test bench::jump_large_db_bench_zoxide_zsh    ... bench:   2,143,692 ns/iter (+/- 62,977)
```

Looks like zoxide's "large db" benchmark performs really well, while the cd and jump benchmarks, it's just a touch slower than pazi.

I guess this is probably another argument to move off msgpack, but for now, I just want to merge the new benchmark so I can track improvements properly.