### PR TITLE
docs: add table of other autojumpers, reference zoxide from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,14 @@ This implementation aims to be faster than any of the others (in no small part
 due to being in [Rust][rust]), and also safer than `fasd` and `z` which, being
 shell-parsers written entirely in shell, are [tricky to get right][fasd-pr].
 
+It's worth specifically noting that [zoxide](https://github.com/ajeetdsouza/zoxide) is another autojumper written in Rust, which has comparable performance <sup><sub>(better performance for some benchmarks currently!)</sub></sup>.
+
+For a more complete list of other autojump programs, refer to the [table here](docs/Autojumpers.md).
+
 ### So, is it faster?
 
 Pazi is faster than the other autojump implementations it has been benchmarked
-against. The results of these benchmarks are documented [here][benchmarks].
+against, excluding zoxide. The results of these benchmarks are documented [here][benchmarks].
 
 ## Status
 

--- a/docs/Autojumpers.md
+++ b/docs/Autojumpers.md
@@ -1,0 +1,12 @@
+## Other Autojumpers
+
+This document is meant to collect the list of other autojumpers, primarily to track what we have and haven't benchmarked against.
+
+| Autojumper | Language | Benchmarked against |
+| --- | ----------- | ------- |
+| [autojump](https://github.com/wting/autojump) | python | :heavy_check_mark: |
+| [jump](https://github.com/gsamokovarov/jump) | go | :heavy_check_mark: |
+| [rupa/z](https://github.com/rupa/z) | shell | :heavy_check_mark: |
+| [fasd](https://github.com/clvv/fasd) | fasd | :heavy_check_mark: |
+| [zoxide](https://github.com/ajeetdsouza/zoxide ) | rust | :heavy_check_mark: |
+| [z.lua](https://github.com/skywind3000/z.lua) | lua | |


### PR DESCRIPTION
We can add features, etc, later as more columns, but for now I wanted to
move the list somewhere I can reference it.

The readme doesn't feel like the right place for an exhaustive list of
em.