### PR TITLE
errno: support FreeBSD

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -620,6 +620,8 @@ fn intercept_ctrl_c() -> Result<(), ()> {
         return libc::__errno_location();
         #[cfg(target_os = "macos")]
         return libc::__error();
+        #[cfg(target_os = "freebsd")]
+        return libc::__error();
     }
 
     unsafe {


### PR DESCRIPTION
FreeBSD 14's errno can be retrieved using the following function:

extern int	* __error();

This is documented in the intro(2) manual page, seen here: https://man.freebsd.org/cgi/man.cgi?query=errno&apropos=0&sektion=0&manpath=FreeBSD+14.0-RELEASE&arch=default&format=html

Fixes: https://github.com/euank/pazi/issues/445