### PR TITLE
Release v0.5.0 :zap::zap:

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pazi"
-version = "0.4.1"
+version = "0.5.0"
 description = "A fast autojump helper"
 authors = ["Euan Kemp <euank@euank.com>"]
 homepage = "https://github.com/euank/pazi"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,13 @@
+## v0.5.0 - 2024-09-02
+
+This release contains a small number of bugfixes and improvements, but no major changes.
+
+### Changes
+
+* New database entries are added in a background process now, improving performance in some cases.
+* A manpage is now included in 'packaging/man/pazi.1'. Package maintainers are included to include this in pazi's package.
+* Various dependency updates.
+
 ## v0.4.1 - 2019-10-29
 
 This is a bugfix release fixing a notable issue in v0.4.0

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -359,7 +359,7 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pazi"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
Time for a release!

Changelog entry:

This release contains a small number of bugfixes and improvements, but no major changes.

### Changes

* New database entries are added in a background process now, improving performance in some cases.
* A manpage is now included in 'packaging/man/pazi.1'. Package maintainers are included to include this in pazi's package.
* Various dependency updates.